### PR TITLE
test: cover issue #40 codicon validation

### DIFF
--- a/test/colours.behavior.test.js
+++ b/test/colours.behavior.test.js
@@ -1,0 +1,63 @@
+var helpers = require( './moduleHelpers.js' );
+
+function createIdentityStub( settings )
+{
+    return {
+        getSetting: function( key, defaultValue )
+        {
+            return Object.prototype.hasOwnProperty.call( settings, key ) ? settings[ key ] : defaultValue;
+        }
+    };
+}
+
+QUnit.module( 'behavioral colours', function()
+{
+    QUnit.test( 'issue #40 codicon named colours report theme colour contract', function( assert )
+    {
+        var colours = helpers.loadWithStubs( '../src/colours.js', {
+            vscode: {},
+            './extensionIdentity.js': createIdentityStub( {
+                'highlights.customHighlight': {
+                    BUG: {},
+                    FIXME: {},
+                    TODO: {}
+                },
+                'highlights.customHighlight.BUG.icon': '$(bug)',
+                'highlights.customHighlight.BUG.iconColour': 'red',
+                'highlights.customHighlight.FIXME.icon': '$(tools)',
+                'highlights.customHighlight.FIXME.iconColour': 'orange',
+                'highlights.customHighlight.TODO.icon': '$(checklist)',
+                'highlights.customHighlight.TODO.iconColour': 'yellow'
+            } )
+        } );
+
+        assert.equal(
+            colours.validateIconColours(),
+            'Invalid icon colour settings: customHighlight.BUG.iconColour (red), ' +
+                'customHighlight.FIXME.iconColour (orange), ' +
+                'customHighlight.TODO.iconColour (yellow). Codicons can only use theme colours.'
+        );
+    } );
+
+    QUnit.test( 'issue #40 codicon theme colours pass icon colour checks', function( assert )
+    {
+        var colours = helpers.loadWithStubs( '../src/colours.js', {
+            vscode: {},
+            './extensionIdentity.js': createIdentityStub( {
+                'highlights.customHighlight': {
+                    BUG: {},
+                    FIXME: {},
+                    TODO: {}
+                },
+                'highlights.customHighlight.BUG.icon': '$(bug)',
+                'highlights.customHighlight.BUG.iconColour': 'editorError.foreground',
+                'highlights.customHighlight.FIXME.icon': '$(tools)',
+                'highlights.customHighlight.FIXME.iconColour': 'editorWarning.foreground',
+                'highlights.customHighlight.TODO.icon': '$(checklist)',
+                'highlights.customHighlight.TODO.iconColour': 'editorInfo.foreground'
+            } )
+        } );
+
+        assert.equal( colours.validateIconColours(), '' );
+    } );
+} );

--- a/test/icons.behavior.test.js
+++ b/test/icons.behavior.test.js
@@ -180,6 +180,31 @@ QUnit.module( 'behavioral icons', function( hooks )
         assert.equal( icons.validateIcons(), '' );
     } );
 
+    QUnit.test( 'issue #40 reported codicon aliases validate', function( assert )
+    {
+        var icons = helpers.loadWithStubs( '../src/icons.js', {
+            vscode: createVscodeStub(),
+            './extensionIdentity.js': createIdentityStub( {
+                'highlights.customHighlight': {
+                    BUG: {},
+                    FIXME: {},
+                    TODO: {},
+                    MOMA: {},
+                    '[ ]': {},
+                    '[x]': {}
+                },
+                'highlights.customHighlight.BUG.icon': '$(bug)',
+                'highlights.customHighlight.FIXME.icon': '$(tools)',
+                'highlights.customHighlight.TODO.icon': '$(checklist)',
+                'highlights.customHighlight.MOMA.icon': '$(unverified)',
+                'highlights.customHighlight.[ ].icon': '$(unlock)',
+                'highlights.customHighlight.[x].icon': '$(lock)'
+            } )
+        } );
+
+        assert.equal( icons.validateIcons(), '' );
+    } );
+
     QUnit.test( 'issue #28 malformed codicon syntax remains invalid', function( assert )
     {
         var icons = helpers.loadWithStubs( '../src/icons.js', {


### PR DESCRIPTION
Add behavioral coverage for the reported codicon aliases and the codicon
icon-colour contract that rejects named colours while accepting theme colours.

Fixes #40