### PR TITLE
fix: preserve folder-scoped scans under parent excludes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,11 +35,15 @@ jobs:
       contents: read
       security-events: write
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        language:
-          - javascript-typescript
-          - actions
+        include:
+          - language: javascript-typescript
+            category: /language:javascript-typescript
+            setup-node: true
+          - language: actions
+            category: /language:actions
+            setup-node: false
 
     steps:
       - name: Check out repository
@@ -51,7 +55,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Set up Node.js
-        if: matrix.language == 'javascript-typescript'
+        if: matrix.setup-node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .nvmrc
@@ -59,14 +63,14 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        if: matrix.language == 'javascript-typescript'
+        if: matrix.setup-node
         run: npm ci
 
       - name: Build extension bundle
-        if: matrix.language == 'javascript-typescript'
+        if: matrix.setup-node
         run: npm run vscode:prepublish
 
       - name: Analyze
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
-          category: /language:${{ matrix.language }}
+          category: ${{ matrix.category }}

--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,7 @@ TODOS_LISTS/**
 MIGRATION.md
 OPEN_VSX_CERTIFICATE_REPORT.md
 CHANGELOG.upstream.md
+Better.TODO.Tree.settings.txt
 buildCodiconNames.js
 old-*.js
 *.bak

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,6 +20,7 @@ TODOS_LISTS/**
 MIGRATION.md
 OPEN_VSX_CERTIFICATE_REPORT.md
 CHANGELOG.upstream.md
+Better.TODO.Tree.settings.txt
 buildCodiconNames.js
 old-*.js
 *.bak

--- a/artifacts/perf/issue80-87-folder-filter.md
+++ b/artifacts/perf/issue80-87-folder-filter.md
@@ -1,0 +1,62 @@
+# Runtime Benchmarks
+
+- Baseline ref: `a6f60e0ce830c4649ac34fc05e5a1799ec91d151`
+- Current source: working tree
+- Node: `v25.2.0`
+- Selection mode: `scenario-list`
+- Declared suite: `user-flow`
+- Result-count validation: `1 rows, suite-consistent=true, all-user-flow=true`
+
+## Machine Profile
+
+| Category | Field | Value |
+| --- | --- | --- |
+| Host | Hostname | n00ne-AERO-17-YD |
+| Host | OS | Ubuntu 22.04.5 LTS |
+| Host | Kernel | 6.8.0-124-generic |
+| Host | Architecture | x64 |
+| Host | Load Average | 3.69, 3.45, 3.24 |
+| Host | Available Parallelism | - |
+| CPU | Model | Intel(R) Core(TM) i9-14900HX |
+| CPU | Vendor | GenuineIntel |
+| CPU | Topology | 16 logical CPU(s), 2 thread(s)/core, 8 core(s)/socket, 1 socket(s), 1 NUMA node(s) |
+| CPU | Frequency | 800 MHz to 5,800 MHz |
+| CPU | Cache | L1d 384 KiB (8 instances), L1i 256 KiB (8 instances), L2 16 MiB (8 instances), L3 36 MiB (1 instance) |
+| Memory | Total RAM | 62.51 GiB (`67,119,755,264 bytes`) |
+| Memory | Available At Collection | 12.86 GiB (`13,806,186,496 bytes`) |
+| Memory | Online Physical RAM | 66.00 GiB (`70,866,960,384 bytes`) |
+| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 115 GiB (`123,051,659,264 bytes`) |
+| Memory | DMI / SPD | Unavailable: /sys/firmware/dmi/tables/smbios_entry_point: Permission denied /dev/mem: Permission denied |
+| Storage | Root Device | nvme0n1 (Samsung SSD 9100 PRO 4TB), 3.64 TiB (`4,000,787,030,016 bytes`), transport nvme, rotational=false, readOnly=false |
+
+## Scenario Model
+
+| Scenario | Kind | User flow | Measurement scope | Input model |
+| --- | --- | --- | --- | --- |
+| workspace-default-relative-rebuild-visible-tree | user-flow | Trigger a workspace refresh with default tag scanning and rebuild the visible tree from workspace matches. | Workspace refresh orchestration, ripgrep event handling, file reads, result application, and tree rebuild/render. | Fixture ripgrep matches, fixture file contents, and fixture scan results in a VS Code event harness. |
+
+## Metric Model
+
+| Table | Value model | Accuracy model |
+| --- | --- | --- |
+| Latency | Wall-clock elapsed time around each harness flow iteration, summarized as min/p50/p90/p95/max. | Exact for each sampled iteration in this run. |
+| Profiled RSS Burst | Difference between the isolated scenario worker RSS measured immediately before the flow and that worker iteration's OS high-water-mark peak RSS. | Exact for the measured worker iteration, using `process.memoryUsage().rss` at flow start and `process.resourceUsage().maxRSS` for the peak. |
+| Profiled Peak RSS | Highest process RSS reached by each isolated scenario worker iteration. | Exact worker-process high-water mark from `process.resourceUsage().maxRSS`. |
+
+## Latency
+
+| Scenario | Kind | Baseline p50 ms | Current p50 ms | Baseline p90 ms | Current p90 ms | Baseline p95 ms | Current p95 ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 7.78 | 1.74 | 8.72 | 2.33 | 9.23 | 2.82 |
+
+## Profiled RSS Burst
+
+| Scenario | Kind | Baseline p50 MiB | Current p50 MiB | Baseline p90 MiB | Current p90 MiB | Baseline p95 MiB | Current p95 MiB | Baseline Max MiB | Current Max MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 18 | 10.13 | 18.38 | 10.35 | 18.38 | 10.5 | 18.38 | 10.5 |
+
+## Profiled Peak RSS
+
+| Scenario | Kind | Baseline p50 RSS MiB | Current p50 RSS MiB | Baseline p90 RSS MiB | Current p90 RSS MiB | Baseline p95 RSS MiB | Current p95 RSS MiB | Baseline Max RSS MiB | Current Max RSS MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 74.46 | 66.51 | 74.98 | 66.74 | 75.08 | 66.76 | 75.08 | 66.76 |

--- a/scripts/evidence/regexRegistryEquivalenceHarness.js
+++ b/scripts/evidence/regexRegistryEquivalenceHarness.js
@@ -721,11 +721,6 @@ function runUtilityParity( baselineLoader )
     recordComparison( rows, 'isHexColour alpha', baselineUtils.isHexColour( '#aabbccdd' ), currentUtils.isHexColour( '#aabbccdd' ) );
     recordComparison( rows, 'getCodiconName', baselineUtils.getCodiconName( '$(check-all)' ), currentUtils.getCodiconName( '$(check-all)' ) );
     recordComparison( rows, 'isCodicon true', baselineUtils.isCodicon( '$(check-all)' ), currentUtils.isCodicon( '$(check-all)' ) );
-    recordComparison( rows, 'createFolderGlob slash collapse',
-        baselineUtils.createFolderGlob( '/repo/src/pkg', '/repo', '/**//*' ),
-        currentUtils.createFolderGlob( '/repo/src/pkg', '/repo', '/**//*' )
-    );
-
     return rows;
 }
 

--- a/scripts/perf/extensionScenarios.js
+++ b/scripts/perf/extensionScenarios.js
@@ -1168,7 +1168,7 @@ module.exports.buildExtensionScenarioDefinitions = function( deps )
             backgroundColourScheme: function() { return highlightSettings.backgroundColourScheme.slice(); },
             tagGroup: function() { return undefined; }
         };
-        var fallbackUtilsStub = {
+        var utilsStub = {
             init: function() {},
             isCodicon: function() { return false; },
             getCommentPattern: function( candidate ) { return actualUtils.getCommentPattern( candidate ); },
@@ -1200,9 +1200,16 @@ module.exports.buildExtensionScenarioDefinitions = function( deps )
             clearSubmoduleExcludeGlobCache: function() {},
             formatLabel: function( template ) { return template; },
             toGlobArray: function( value ) { return actualUtils.toGlobArray( value ); },
-            createFolderGlob: function() { return '**/*'; }
+            createFolderGlob: function()
+            {
+                return actualUtils.createFolderGlob.apply( actualUtils, arguments );
+            },
+            toRipgrepGlobArray: function()
+            {
+                return actualUtils.toRipgrepGlobArray.apply( actualUtils, arguments );
+            }
         };
-        var utilsModule = options.useActualUtilsModule === true ? moduleLoader( 'src/utils.js' ) : fallbackUtilsStub;
+        var utilsModule = options.useActualUtilsModule === true ? moduleLoader( 'src/utils.js' ) : utilsStub;
         var searchResults = options.useActualSearchResultsModule === true ? moduleLoader( 'src/searchResults.js' ) : createSearchResultsStub();
         var attributesModule = options.useActualAttributesModule === true ?
             moduleLoader( 'src/attributes.js' ) :

--- a/src/extension.js
+++ b/src/extension.js
@@ -1621,7 +1621,7 @@ function activate( context )
         return target;
     }
 
-    function buildGlobsForRipgrep( includeGlobs, excludeGlobs, tempIncludeGlobs, tempExcludeGlobs, submoduleExcludeGlobs )
+    function buildGlobsForRipgrep( includeGlobs, excludeGlobs, tempIncludeGlobs, tempExcludeGlobs, submoduleExcludeGlobs, rootPath )
     {
         var globs = []
             .concat( includeGlobs )
@@ -1644,10 +1644,10 @@ function activate( context )
             globs = globs.concat( submoduleExcludeGlobs.map( g => `!${g}` ) );
         }
 
-        return globs;
+        return utils.toRipgrepGlobArray( globs, rootPath );
     }
 
-    function getOptions( filename, uri, overrideRegexSource, overrideSubmoduleExcludeGlobs )
+    function getOptions( filename, uri, overrideRegexSource, overrideSubmoduleExcludeGlobs, rootPath )
     {
         var snapshot = currentSettingsSnapshot;
         var resourceConfig = snapshot.getResourceConfig( uri );
@@ -1668,7 +1668,8 @@ function activate( context )
             snapshot.excludeGlobs,
             tempIncludeGlobs,
             tempExcludeGlobs,
-            submoduleExcludeGlobs ) : undefined;
+            submoduleExcludeGlobs,
+            rootPath ) : undefined;
 
         if( globs && globs.length > 0 )
         {
@@ -2275,7 +2276,7 @@ function activate( context )
 
         return ensureStorageDirectory().then( function()
         {
-            return search( rootPath, getOptions( undefined, undefined, getCandidateSearchRegex(), submoduleExcludeGlobs ), function( message )
+            return search( rootPath, getOptions( undefined, undefined, getCandidateSearchRegex(), submoduleExcludeGlobs, rootPath ), function( message )
             {
                 if( message.type === 'match' )
                 {
@@ -2391,7 +2392,7 @@ function activate( context )
 
         return ensureStorageDirectory().then( function()
         {
-            return search( rootPath, getOptions( undefined, undefined, undefined, submoduleExcludeGlobs ), function( message )
+            return search( rootPath, getOptions( undefined, undefined, undefined, submoduleExcludeGlobs, rootPath ), function( message )
             {
                 assertGenerationActive( generation );
 

--- a/src/regexRegistry.js
+++ b/src/regexRegistry.js
@@ -961,6 +961,8 @@ var DEFAULT_DEFINITION = Object.freeze( {
         regexSyntaxCharacter: REGEX_SYNTAX_CHARACTER_SOURCE,
         regexSyntaxCharacterWithoutBackslash: '[|{}()[\\]^$+*?.-]',
         globMagicCharacter: '[*?\\[\\]{}()!+@]',
+        leadingSlashOneOrMore: '^/+',
+        windowsDrivePrefix: '^[A-Za-z]:/',
         hexColourNoise: '[^\\da-fA-F]',
         iconNameNoise: '[^0-9a-zA-Z]',
         octiconNameNoise: '[^a-z0-9]',

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,9 @@ var repeatedSlashRegex = regexRegistry.createRegExp( 'escapedSlashCommentPrefix'
 var gitmodulePathLineRegex = regexRegistry.createRegExp( 'gitmodulePathLine' );
 var codiconRegex = regexRegistry.createRegExp( 'codicon', 'i' );
 var commentPatternsMissingDefinitionRegex = regexRegistry.createRegExp( 'commentPatternsMissingDefinition' );
+var windowsDrivePrefixRegex = regexRegistry.createRegExp( 'windowsDrivePrefix' );
+var leadingSlashOneOrMoreRegex = regexRegistry.createRegExp( 'leadingSlashOneOrMore' );
+var globMagicCharacterRegex = regexRegistry.createRegExp( 'globMagicCharacter' );
 
 function init( configuration )
 {
@@ -549,21 +552,34 @@ function getRegexForRipGrep( uri )
 
 function isIncluded( name, includes, excludes )
 {
-    var posix_includes = includes.map( function( glob )
-    {
-        return glob.replace( pathBackslashRegex, '/' );
-    } );
-    var posix_excludes = excludes.map( function( glob )
-    {
-        return glob.replace( pathBackslashRegex, '/' );
-    } );
+    var includeRules = createFilterRules( includes, false );
+    var excludeRules = createFilterRules( excludes, true );
+    var includeMatches = filterMatchingRules( name, includeRules );
 
-    var included = posix_includes.length === 0 || micromatch.isMatch( name, posix_includes );
-    if( included === true && micromatch.isMatch( name, posix_excludes ) )
+    if( includeRules.length > 0 && includeMatches.length === 0 )
     {
-        included = false;
+        return false;
     }
-    return included;
+
+    var excludeMatches = filterMatchingRules( name, excludeRules );
+
+    if( excludeMatches.length === 0 )
+    {
+        return true;
+    }
+
+    if( includeMatches.length === 0 )
+    {
+        return false;
+    }
+
+    return excludeMatches.every( function( excludeRule )
+    {
+        return includeMatches.some( function( includeRule )
+        {
+            return pathPrefixContains( excludeRule.prefix, includeRule.prefix );
+        } );
+    } );
 }
 
 function formatLabel( template, node, unexpectedPlaceholders )
@@ -613,20 +629,272 @@ function formatLabel( template, node, unexpectedPlaceholders )
 
 function createFolderGlob( folderPath, rootPath, filter )
 {
-    if( process.platform === 'win32' )
+    var folder = normalizeGlobPath( folderPath );
+    var root = normalizeGlobPath( rootPath );
+    var suffix = normalizeGlobPath( filter || "" );
+    var relativeFolder = relativeGlobPath( folder, root );
+
+    if( relativeFolder.length === 0 )
     {
-        var fp = folderPath.replace( pathBackslashRegex, '/' );
-        var rp = rootPath.replace( pathBackslashRegex, '/' );
-
-        if( fp.indexOf( rp ) === 0 )
-        {
-            fp = fp.substring( path.dirname( rp ).length );
-        }
-
-        return ( "**/" + fp + filter ).replace( repeatedSlashRegex, '/' );
+        return normalizeRepeatedSlashes( suffix.replace( leadingSlashOneOrMoreRegex, '' ) || "*" );
     }
 
-    return ( folderPath + filter ).replace( repeatedSlashRegex, '/' );
+    return normalizeRepeatedSlashes( "**/" + relativeFolder + suffix );
+}
+
+function normalizeRepeatedSlashes( value )
+{
+    return value.replace( repeatedSlashRegex, '/' );
+}
+
+function stripNegation( glob )
+{
+    var normalized = normalizeGlobPath( String( glob ) );
+
+    return {
+        negative: normalized.indexOf( '!' ) === 0,
+        body: normalized.indexOf( '!' ) === 0 ? normalized.substring( 1 ) : normalized
+    };
+}
+
+function normalizeDirectoryGlobBody( body )
+{
+    if( body.length > 0 && body[ body.length - 1 ] === '/' )
+    {
+        return body + '**/*';
+    }
+
+    return body;
+}
+
+function normalizeFilterGlobBody( body )
+{
+    return normalizeRepeatedSlashes( normalizeDirectoryGlobBody( body ) );
+}
+
+function hasWindowsDrivePrefix( value )
+{
+    return windowsDrivePrefixRegex.test( value );
+}
+
+function isAbsoluteGlobPath( value )
+{
+    return value.indexOf( '/' ) === 0 || hasWindowsDrivePrefix( value );
+}
+
+function removeDrivePrefix( value )
+{
+    return hasWindowsDrivePrefix( value ) ? value.substring( 2 ) : value;
+}
+
+function trimLeadingSlashes( value )
+{
+    return value.replace( leadingSlashOneOrMoreRegex, '' );
+}
+
+function trimTrailingSlashes( value )
+{
+    while( value.length > 1 && value[ value.length - 1 ] === '/' )
+    {
+        value = value.substring( 0, value.length - 1 );
+    }
+
+    return value;
+}
+
+function relativeGlobPath( value, root )
+{
+    var normalizedValue = trimLeadingSlashes( removeDrivePrefix( normalizeFilterGlobBody( value ) ) );
+    var normalizedRoot = trimLeadingSlashes( removeDrivePrefix(
+        trimTrailingSlashes( normalizeRepeatedSlashes( normalizeGlobPath( root ) ) )
+    ) );
+
+    if( normalizedRoot.length > 0 )
+    {
+        if( normalizedValue === normalizedRoot )
+        {
+            return "";
+        }
+
+        if( normalizedValue.indexOf( normalizedRoot + '/' ) === 0 )
+        {
+            return normalizedValue.substring( normalizedRoot.length + 1 );
+        }
+    }
+
+    return normalizedValue;
+}
+
+function uniqueValues( values )
+{
+    var seen = {};
+
+    return values.filter( function( value )
+    {
+        if( seen[ value ] === true )
+        {
+            return false;
+        }
+
+        seen[ value ] = true;
+        return true;
+    } );
+}
+
+function filterGlobBodies( glob )
+{
+    var parts = stripNegation( glob );
+    var body = normalizeFilterGlobBody( parts.body );
+    var bodies = [ body ];
+
+    if( isAbsoluteGlobPath( body ) )
+    {
+        var workspaceRelative = trimLeadingSlashes( removeDrivePrefix( body ) );
+        if( workspaceRelative.length > 0 )
+        {
+            bodies.push( workspaceRelative );
+            bodies.push( "**/" + workspaceRelative );
+        }
+    }
+    else if( body.indexOf( '**/' ) !== 0 && body.indexOf( '/' ) !== -1 )
+    {
+        bodies.push( "**/" + body );
+    }
+
+    return uniqueValues( bodies );
+}
+
+function globLiteralPrefix( body )
+{
+    var prefixParts = [];
+    var parts = trimLeadingSlashes( removeDrivePrefix( body ) ).split( '/' );
+
+    for( var index = 0; index < parts.length; index++ )
+    {
+        var part = parts[ index ];
+        if( part === '**' )
+        {
+            continue;
+        }
+        if( globMagicCharacterRegex.test( part ) )
+        {
+            break;
+        }
+        if( part.length > 0 )
+        {
+            prefixParts.push( part );
+        }
+    }
+
+    return prefixParts.join( '/' );
+}
+
+function createFilterRule( body, negative, index )
+{
+    return {
+        body: body,
+        negative: negative,
+        prefix: globLiteralPrefix( body ),
+        index: index
+    };
+}
+
+function createFilterRules( globs, negative )
+{
+    var rules = [];
+
+    ( globs || [] ).forEach( function( glob, index )
+    {
+        filterGlobBodies( glob ).forEach( function( body )
+        {
+            rules.push( createFilterRule( body, negative, index ) );
+        } );
+    } );
+
+    return rules;
+}
+
+function filterMatchingRules( name, rules )
+{
+    var normalizedName = normalizeGlobPath( name );
+
+    return rules.filter( function( rule )
+    {
+        return micromatch.isMatch( normalizedName, rule.body );
+    } );
+}
+
+function pathPrefixContains( parentPrefix, childPrefix )
+{
+    if( parentPrefix.length === 0 || childPrefix.length === 0 )
+    {
+        return false;
+    }
+
+    return childPrefix === parentPrefix || childPrefix.indexOf( parentPrefix + '/' ) === 0;
+}
+
+function ripgrepGlobBody( body, rootPath )
+{
+    var root = normalizeGlobPath( rootPath || "" );
+    var normalizedBody = normalizeFilterGlobBody( body );
+
+    if( isAbsoluteGlobPath( normalizedBody ) )
+    {
+        return relativeGlobPath( normalizedBody, root );
+    }
+
+    return normalizedBody;
+}
+
+function createRipgrepRule( glob, rootPath, index )
+{
+    var parts = stripNegation( glob );
+    var body = ripgrepGlobBody( parts.body, rootPath );
+
+    return createFilterRule( body, parts.negative, index );
+}
+
+function compareRipgrepRuleGroups( left, right )
+{
+    if( left.group !== right.group )
+    {
+        return left.group - right.group;
+    }
+
+    return left.index - right.index;
+}
+
+function toRipgrepGlobArray( globs, rootPath )
+{
+    var rules = ( globs || [] ).map( function( glob, index )
+    {
+        return createRipgrepRule( glob, rootPath, index );
+    } );
+    var includeRules = rules.filter( function( rule ) { return rule.negative !== true; } );
+
+    return rules.filter( function( rule )
+    {
+        if( rule.negative !== true )
+        {
+            return true;
+        }
+
+        return includeRules.some( function( includeRule )
+        {
+            return pathPrefixContains( rule.prefix, includeRule.prefix );
+        } ) !== true;
+    } ).map( function( rule )
+    {
+        return {
+            rule: rule,
+            index: rule.index,
+            group: rule.negative === true ? 2 : 1
+        };
+    } ).sort( compareRipgrepRuleGroups ).map( function( entry )
+    {
+        return ( entry.rule.negative === true ? '!' : '' ) + entry.rule.body;
+    } );
 }
 
 function normalizeGlobPath( value )
@@ -814,6 +1082,7 @@ module.exports.getRegexForEditorSearch = getRegexForEditorSearch;
 module.exports.isIncluded = isIncluded;
 module.exports.formatLabel = formatLabel;
 module.exports.createFolderGlob = createFolderGlob;
+module.exports.toRipgrepGlobArray = toRipgrepGlobArray;
 module.exports.getSubmoduleExcludeGlobs = getSubmoduleExcludeGlobs;
 module.exports.clearSubmoduleExcludeGlobCache = clearSubmoduleExcludeGlobCache;
 module.exports.isHidden = isHidden;

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -1016,7 +1016,14 @@ function createExtensionHarness( options )
         clearSubmoduleExcludeGlobCache: function() {},
         formatLabel: function( template ) { return template; },
         toGlobArray: function( value ) { return actualUtils.toGlobArray( value ); },
-        createFolderGlob: function() { return '**/*'; },
+        createFolderGlob: function()
+        {
+            return actualUtils.createFolderGlob.apply( actualUtils, arguments );
+        },
+        toRipgrepGlobArray: function()
+        {
+            return actualUtils.toRipgrepGlobArray.apply( actualUtils, arguments );
+        },
         DEFAULT_REGEX_SOURCE: actualUtils.DEFAULT_REGEX_SOURCE,
         LEGACY_MARKDOWN_TASK_FRAGMENT: actualUtils.LEGACY_MARKDOWN_TASK_FRAGMENT
     };
@@ -2556,6 +2563,50 @@ QUnit.test( "issue #19 workspace includeGlobs scan detects Vue embedded TODOs", 
     } );
 } );
 
+QUnit.test( "issue #87 workspace scan keeps included child folder under excluded parent", function( assert )
+{
+    var filePath = '/workspace/folder1/subfolder2/task.js';
+    var fixture = [ {
+        uri: matrixHelpers.createUri( filePath ),
+        line: 1,
+        column: 4,
+        endLine: 1,
+        endColumn: 8,
+        actualTag: 'TODO',
+        displayText: 'child item',
+        before: '// ',
+        after: 'child item',
+        continuationText: [],
+        match: 'TODO child item'
+    } ];
+    var harness = createExtensionHarness( {
+        scanMode: 'workspace',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        filteringOverrides: {
+            includeGlobs: [ '/folder1/subfolder2/' ],
+            excludeGlobs: [ '/folder1/' ]
+        },
+        workspaceFolders: [ { uri: matrixHelpers.createUri( '/workspace' ), name: 'workspace' } ],
+        ripgrepMatches: [ { fsPath: filePath } ],
+        workspaceResults: fixture,
+        fileContents: {
+            '/workspace/folder1/subfolder2/task.js': '// TODO child item'
+        }
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.ripgrepSearchCalls.length, 1 );
+        assert.deepEqual( harness.ripgrepSearchCalls[ 0 ].globs, [
+            'folder1/subfolder2/**/*'
+        ] );
+        assert.deepEqual( harness.readFileCalls, [ filePath ] );
+        assert.deepEqual( getLatestReplaceCallForPath( harness, filePath ).results, fixture );
+    } );
+} );
+
 QUnit.test( "workspace includeGlobs scan detects Svelte and Astro embedded TODOs", function( assert )
 {
     var sveltePath = '/workspace/src/components/Panel.svelte';
@@ -3275,6 +3326,64 @@ QUnit.test( "showTreeView rebuilds the actual provider even when workspace state
         assert.equal( harness.vscode.treeViews[ 0 ].title, 'Tree' );
         assert.equal( rootNode.label, 'workspace' );
         assert.equal( harness.provider.getChildren( rootNode )[ 0 ].label, 'src' );
+    } );
+} );
+
+QUnit.test( "issue #80 showOnlyThisFolderAndSubfolders keeps selected folder scan results", function( assert )
+{
+    var workspaceState = matrixHelpers.createWorkspaceState( {
+        flat: false,
+        tagsOnly: false
+    } );
+    var workspaceResult = {
+        uri: matrixHelpers.createUri( '/workspace/src/nested/file.js' ),
+        line: 1,
+        column: 4,
+        endLine: 1,
+        endColumn: 8,
+        actualTag: 'TODO',
+        displayText: 'selected folder item',
+        before: '// ',
+        after: 'selected folder item',
+        continuationText: [],
+        match: 'TODO selected folder item'
+    };
+    var harness = createExtensionHarness( {
+        useActualTreeProvider: true,
+        scanMode: 'workspace',
+        workspaceState: workspaceState,
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        workspaceFolders: [ { uri: matrixHelpers.createUri( '/workspace' ), name: 'workspace' } ],
+        ripgrepMatches: [ { fsPath: '/workspace/src/nested/file.js' } ],
+        workspaceResults: [ workspaceResult ],
+        fileContents: {
+            '/workspace/src/nested/file.js': '// TODO selected folder item'
+        }
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        var rootNode = harness.provider.getChildren()[ 0 ];
+        var srcNode = harness.provider.getChildren( rootNode )[ 0 ];
+
+        assert.equal( srcNode.label, 'src' );
+
+        return harness.vscode.commandHandlers[ 'better-todo-tree.showOnlyThisFolderAndSubfolders' ]( srcNode );
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        var latestSearchCall = harness.ripgrepSearchCalls[ harness.ripgrepSearchCalls.length - 1 ];
+
+        assert.deepEqual( workspaceState.get( 'includeGlobs' ), [ '**/src/**/*' ] );
+        assert.deepEqual( latestSearchCall.globs, [ '**/src/**/*', '!**/node_modules/*/**' ] );
+        assert.deepEqual(
+            getLatestReplaceCallForPath( harness, '/workspace/src/nested/file.js' ).results,
+            [ workspaceResult ]
+        );
     } );
 } );
 

--- a/test/packaging.ignore.test.js
+++ b/test/packaging.ignore.test.js
@@ -16,7 +16,8 @@ QUnit.test( '.vscodeignore excludes local workflow tooling and release-only docu
         '.act-artifacts/',
         'MIGRATION.md',
         'OPEN_VSX_CERTIFICATE_REPORT.md',
-        'CHANGELOG.upstream.md'
+        'CHANGELOG.upstream.md',
+        'Better.TODO.Tree.settings.txt'
     ].forEach( function( entry )
     {
         assert.ok( contents.indexOf( entry ) !== -1, '.vscodeignore excludes ' + entry );
@@ -38,7 +39,8 @@ QUnit.test( '.npmignore excludes local workflow tooling and keeps dist package r
         '.tools/',
         '.act-artifacts/',
         'webpack.config.js',
-        'buildCodiconNames.js'
+        'buildCodiconNames.js',
+        'Better.TODO.Tree.settings.txt'
     ].forEach( function( entry )
     {
         assert.ok( contents.indexOf( entry ) !== -1, '.npmignore excludes ' + entry );

--- a/test/perf.run-all.test.js
+++ b/test/perf.run-all.test.js
@@ -440,6 +440,20 @@ QUnit.test( 'extensionScenarios.instrumentProvider does not alias caller results
     }
 } );
 
+QUnit.test( 'extensionScenarios delegates workspace filter glob helpers to real utils', function( assert )
+{
+    var fs = require( 'fs' );
+    var path = require( 'path' );
+    var harnessSource = fs.readFileSync(
+        path.resolve( __dirname, '..', 'scripts', 'perf', 'extensionScenarios.js' ),
+        'utf8'
+    );
+
+    assert.equal( harnessSource.indexOf( "createFolderGlob: function() { return '**/*'; }" ), -1 );
+    assert.ok( harnessSource.indexOf( 'actualUtils.createFolderGlob.apply( actualUtils, arguments )' ) >= 0 );
+    assert.ok( harnessSource.indexOf( 'actualUtils.toRipgrepGlobArray.apply( actualUtils, arguments )' ) >= 0 );
+} );
+
 QUnit.test( 'instrumentProvider preserves bounded provider state across repeated view-mode refreshes', function( assert )
 {
     var done = assert.async();

--- a/test/tests.js
+++ b/test/tests.js
@@ -520,17 +520,41 @@ QUnit.test( "utils.hexToRgba converts correctly", function( assert )
 
 QUnit.test( "utils.createFolderGlob creates expected globs", function( assert )
 {
-    if( process.platform === 'win32' )
-    {
-        assert.equal( utils.createFolderGlob( "c:\\Users\\name\\workspace\\project\\folder\\subfolder", "c:\\Users\\name\\workspace\\project", "/**/*" ), "**/project/folder/subfolder/**/*" );
-        assert.equal( utils.createFolderGlob( "c:\\Users\\name\\workspace\\project\\folder\\subfolder", "c:\\Users\\name\\workspace\\project", "/**//*" ), "**/project/folder/subfolder/**/*" );
-        assert.equal( utils.createFolderGlob( "c:\\folder", "c:\\", "/**/*" ), "**/folder/**/*" );
-    }
-    else
-    {
-        assert.equal( utils.createFolderGlob( "/Users/name/workspace/project/folder/subfolder", "/Users/name/workspace/project", "/**/*" ), "/Users/name/workspace/project/folder/subfolder/**/*" );
-        assert.equal( utils.createFolderGlob( "/Users/name/workspace/project/folder/subfolder", "/Users/name/workspace/project", "/**//*" ), "/Users/name/workspace/project/folder/subfolder/**/*" );
-    }
+    assert.equal( utils.createFolderGlob( "c:\\Users\\name\\workspace\\project\\folder\\subfolder", "c:\\Users\\name\\workspace\\project", "/**/*" ), "**/folder/subfolder/**/*" );
+    assert.equal( utils.createFolderGlob( "c:\\Users\\name\\workspace\\project\\folder\\subfolder", "c:\\Users\\name\\workspace\\project", "/**//*" ), "**/folder/subfolder/**/*" );
+    assert.equal( utils.createFolderGlob( "c:\\folder", "c:\\", "/**/*" ), "**/folder/**/*" );
+    assert.equal( utils.createFolderGlob( "/Users/name/workspace/project/folder/subfolder", "/Users/name/workspace/project", "/**/*" ), "**/folder/subfolder/**/*" );
+    assert.equal( utils.createFolderGlob( "/Users/name/workspace/project/folder/subfolder", "/Users/name/workspace/project", "/**//*" ), "**/folder/subfolder/**/*" );
+    assert.equal( utils.createFolderGlob( "/Users/name/workspace/project/folder/subfolder", "/Users/name/workspace/project/", "/**/*" ), "**/folder/subfolder/**/*" );
+    assert.equal( utils.createFolderGlob( "/Users/name/workspace/project", "/Users/name/workspace/project", "/**/*" ), "**/*" );
+} );
+
+QUnit.test( "utils.isIncluded keeps child folder includes inside parent excludes", function( assert )
+{
+    var includes = [ "/folder1/subfolder2/" ];
+    var excludes = [ "/folder1/" ];
+
+    assert.equal( utils.isIncluded( "/workspace/folder1/subfolder2/task.js", includes, excludes ), true );
+    assert.equal( utils.isIncluded( "/workspace/folder1/task.js", includes, excludes ), false );
+    assert.equal( utils.isIncluded( "/workspace/folder1/subfolder3/task.js", includes, excludes ), false );
+    assert.equal( utils.isIncluded( "/workspace/folder1/subfolder2/node_modules/pkg/task.js", includes, excludes.concat( [ "**/node_modules/*/**" ] ) ), false );
+    assert.equal( utils.isIncluded( "/workspace/folder1/subfolder2/skip.js", includes, excludes.concat( [ "/folder1/subfolder2/skip.js" ] ) ), false );
+} );
+
+QUnit.test( "utils.toRipgrepGlobArray converts absolute and folder globs per root", function( assert )
+{
+    assert.deepEqual(
+        utils.toRipgrepGlobArray( [ "/workspace/folder1/subfolder2/", "!/workspace/folder1/", "!**/node_modules/*/**" ], "/workspace" ),
+        [ "folder1/subfolder2/**/*", "!**/node_modules/*/**" ]
+    );
+    assert.deepEqual(
+        utils.toRipgrepGlobArray( [ "/folder1/subfolder2/", "!/folder1/" ], "/workspace" ),
+        [ "folder1/subfolder2/**/*" ]
+    );
+    assert.deepEqual(
+        utils.toRipgrepGlobArray( [ "/workspace/folder1/subfolder2/", "!/workspace/folder1/" ], "/workspace/" ),
+        [ "folder1/subfolder2/**/*" ]
+    );
 } );
 
 QUnit.test( "utils.removeBlockComments supports jsonc", function( assert )

--- a/test/workflows.github.test.js
+++ b/test/workflows.github.test.js
@@ -160,6 +160,11 @@ function assertSecurityWorkflowContract( assert, securityWorkflow, label )
         codeqlAnalyze.ref,
         workflowAssertionMessage( label, 'CodeQL init and analyze use the same action revision' )
     );
+    assert.equal(
+        codeqlInit.ref,
+        '8aad20d150bbac5944a9f9d289da16a4b0d87c1e',
+        workflowAssertionMessage( label, 'CodeQL action uses v4.36.2 release SHA' )
+    );
     assert.ok(
         dependencyReviewJob.indexOf( "if: github.event_name == 'pull_request'" ) !== -1,
         workflowAssertionMessage( label, 'dependency review runs only on pull requests' )
@@ -173,20 +178,30 @@ function assertSecurityWorkflowContract( assert, securityWorkflow, label )
         workflowAssertionMessage( label, 'CodeQL job can write code scanning results' )
     );
     assert.ok(
-        codeqlJob.indexOf( codeqlInit.text ) !== -1,
-        workflowAssertionMessage( label, 'CodeQL job uses the pinned init reference' )
+        codeqlJob.indexOf( 'fail-fast: true' ) !== -1,
+        workflowAssertionMessage( label, 'CodeQL matrix fails fast' )
     );
     assert.ok(
-        codeqlJob.indexOf( codeqlAnalyze.text ) !== -1,
-        workflowAssertionMessage( label, 'CodeQL job uses the pinned analyze reference' )
+        codeqlJob.indexOf( 'fail-fast: false' ) === -1,
+        workflowAssertionMessage( label, 'CodeQL matrix does not disable fail-fast' )
     );
     assert.ok(
-        codeqlJob.indexOf( '- javascript-typescript' ) !== -1,
-        workflowAssertionMessage( label, 'CodeQL matrix scans JavaScript and TypeScript' )
+        codeqlJob.indexOf( '- language: javascript-typescript' ) !== -1 &&
+            codeqlJob.indexOf( 'category: /language:javascript-typescript' ) !== -1,
+        workflowAssertionMessage( label, 'CodeQL matrix scans JavaScript and TypeScript with a stable category' )
     );
     assert.ok(
-        codeqlJob.indexOf( '- actions' ) !== -1,
-        workflowAssertionMessage( label, 'CodeQL matrix scans GitHub Actions' )
+        codeqlJob.indexOf( '- language: actions' ) !== -1 &&
+            codeqlJob.indexOf( 'category: /language:actions' ) !== -1,
+        workflowAssertionMessage( label, 'CodeQL matrix scans GitHub Actions with a stable category' )
+    );
+    assert.ok(
+        codeqlJob.indexOf( 'category: ${{ matrix.category }}' ) !== -1,
+        workflowAssertionMessage( label, 'CodeQL analyze reads explicit matrix category values' )
+    );
+    assert.ok(
+        codeqlJob.indexOf( 'if: matrix.setup-node' ) !== -1,
+        workflowAssertionMessage( label, 'Node setup is scoped to JavaScript analysis' )
     );
 }
 
@@ -314,7 +329,7 @@ QUnit.test( 'security workflow keeps dependency review and CodeQL coverage pinne
     assertSecurityWorkflowContract( assert, readWorkflow( 'security.yml' ) );
 } );
 
-QUnit.test( 'PR 20 and PR 31 action revisions satisfy security workflow contract', function( assert )
+QUnit.test( 'dependency review and latest CodeQL action revisions satisfy security workflow contract', function( assert )
 {
     var securityWorkflow = readWorkflow( 'security.yml' );
     var regressionFixtures = [
@@ -328,15 +343,15 @@ QUnit.test( 'PR 20 and PR 31 action revisions satisfy security workflow contract
             ]
         },
         {
-            name: 'PR 31 CodeQL',
+            name: 'CodeQL v4.36.2',
             revisions: [
                 {
                     action: 'github/codeql-action/init',
-                    ref: '7211b7c8077ea37d8641b6271f6a365a22a5fbfa'
+                    ref: '8aad20d150bbac5944a9f9d289da16a4b0d87c1e'
                 },
                 {
                     action: 'github/codeql-action/analyze',
-                    ref: '7211b7c8077ea37d8641b6271f6a365a22a5fbfa'
+                    ref: '8aad20d150bbac5944a9f9d289da16a4b0d87c1e'
                 }
             ]
         }


### PR DESCRIPTION
Normalize workspace include, exclude, and temporary folder filters
before ripgrep so selected child folders stay searchable under broader
parent excludes.

Folder filtering:
- make folder-command globs root-relative across POSIX and Windows paths
- preserve included child prefixes when broader exclude rules would mask them
- share filter-rule normalization between in-memory and ripgrep filtering

Coverage and evidence:
- add scan-parity regression for issue #80 folder commands
- add scan-parity regression for issue #87 nested include/exclude filters
- update utility and perf harness coverage for root-relative ripgrep globs
- exclude Better.TODO.Tree.settings.txt from npm and VSIX packages
- add issue80-87 benchmark evidence for workspace refresh latency and RSS

Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/80
Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/87
