### PR TITLE
fix: restore visible editor highlight lifecycle and contrast

### DIFF
--- a/artifacts/perf/issue58-61-93-highlights.md
+++ b/artifacts/perf/issue58-61-93-highlights.md
@@ -1,0 +1,70 @@
+# Runtime Benchmarks
+
+- Baseline ref: `a6f60e0ce830c4649ac34fc05e5a1799ec91d151`
+- Current source: working tree
+- Node: `v25.2.0`
+- Selection mode: `scenario-list`
+- Declared suite: `user-flow`
+- Result-count validation: `3 rows, suite-consistent=true, all-user-flow=true`
+
+## Machine Profile
+
+| Category | Field | Value |
+| --- | --- | --- |
+| Host | Hostname | n00ne-AERO-17-YD |
+| Host | OS | Ubuntu 22.04.5 LTS |
+| Host | Kernel | 6.8.0-124-generic |
+| Host | Architecture | x64 |
+| Host | Load Average | 6.83, 6.21, 5.78 |
+| Host | Available Parallelism | - |
+| CPU | Model | Intel(R) Core(TM) i9-14900HX |
+| CPU | Vendor | GenuineIntel |
+| CPU | Topology | 16 logical CPU(s), 2 thread(s)/core, 8 core(s)/socket, 1 socket(s), 1 NUMA node(s) |
+| CPU | Frequency | 800 MHz to 5,800 MHz |
+| CPU | Cache | L1d 384 KiB (8 instances), L1i 256 KiB (8 instances), L2 16 MiB (8 instances), L3 36 MiB (1 instance) |
+| Memory | Total RAM | 62.51 GiB (`67,119,755,264 bytes`) |
+| Memory | Available At Collection | 28.58 GiB (`30,685,663,232 bytes`) |
+| Memory | Online Physical RAM | 66.00 GiB (`70,866,960,384 bytes`) |
+| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 83.55 GiB (`89,709,338,624 bytes`) |
+| Memory | DMI / SPD | Unavailable: /sys/firmware/dmi/tables/smbios_entry_point: Permission denied /dev/mem: Permission denied |
+| Storage | Root Device | nvme0n1 (Samsung SSD 9100 PRO 4TB), 3.64 TiB (`4,000,787,030,016 bytes`), transport nvme, rotational=false, readOnly=false |
+
+## Scenario Model
+
+| Scenario | Kind | User flow | Measurement scope | Input model |
+| --- | --- | --- | --- | --- |
+| visible-editor-highlight-open-file | user-flow | Focus or open a visible editor and apply highlights to that editor. | Active-editor event handling, decoration creation/update, and highlight application. | Fixture scan results fed into the real highlight pipeline in a VS Code event harness. |
+| visible-editor-highlight-change-open-file | user-flow | Edit a visible file and refresh its highlights. | Text-change event handling, decoration update, and highlight application. | Fixture scan results fed into the real highlight pipeline in a VS Code event harness. |
+| visible-editor-custom-highlight-config-open-file | user-flow | Open a visible editor while a large custom highlight configuration is active and apply highlights. | Custom-highlight attribute lookup, decoration creation/update, and highlight application. | Fixture scan results plus a large custom-highlight config in a VS Code event harness. |
+
+## Metric Model
+
+| Table | Value model | Accuracy model |
+| --- | --- | --- |
+| Latency | Wall-clock elapsed time around each harness flow iteration, summarized as min/p50/p90/p95/max. | Exact for each sampled iteration in this run. |
+| Profiled RSS Burst | Difference between the isolated scenario worker RSS measured immediately before the flow and that worker iteration's OS high-water-mark peak RSS. | Exact for the measured worker iteration, using `process.memoryUsage().rss` at flow start and `process.resourceUsage().maxRSS` for the peak. |
+| Profiled Peak RSS | Highest process RSS reached by each isolated scenario worker iteration. | Exact worker-process high-water mark from `process.resourceUsage().maxRSS`. |
+
+## Latency
+
+| Scenario | Kind | Baseline p50 ms | Current p50 ms | Baseline p90 ms | Current p90 ms | Baseline p95 ms | Current p95 ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| visible-editor-highlight-open-file | user-flow | 21.99 | 1.85 | 24.44 | 2.56 | 25.49 | 2.74 |
+| visible-editor-highlight-change-open-file | user-flow | 19.89 | 1.88 | 22.15 | 2.62 | 22.25 | 2.83 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 1892.85 | 2.92 | 1925.68 | 4.26 | 1927.01 | 4.33 |
+
+## Profiled RSS Burst
+
+| Scenario | Kind | Baseline p50 MiB | Current p50 MiB | Baseline p90 MiB | Current p90 MiB | Baseline p95 MiB | Current p95 MiB | Baseline Max MiB | Current Max MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| visible-editor-highlight-open-file | user-flow | 47.88 | 14.45 | 49.38 | 14.88 | 49.5 | 15 | 49.5 | 15 |
+| visible-editor-highlight-change-open-file | user-flow | 48 | 14.38 | 49.25 | 14.88 | 49.63 | 15 | 49.63 | 15 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 160.59 | 14.97 | 162.88 | 15.23 | 163.25 | 15.25 | 163.25 | 15.25 |
+
+## Profiled Peak RSS
+
+| Scenario | Kind | Baseline p50 RSS MiB | Current p50 RSS MiB | Baseline p90 RSS MiB | Current p90 RSS MiB | Baseline p95 RSS MiB | Current p95 RSS MiB | Baseline Max RSS MiB | Current Max RSS MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| visible-editor-highlight-open-file | user-flow | 104.39 | 71.12 | 105.7 | 71.23 | 106.22 | 71.6 | 106.22 | 71.6 |
+| visible-editor-highlight-change-open-file | user-flow | 104.84 | 70.91 | 105.96 | 71.34 | 106.34 | 71.75 | 106.34 | 71.75 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 217.21 | 71.44 | 219.47 | 71.77 | 220.12 | 71.96 | 220.12 | 71.96 |

--- a/artifacts/perf/issue58-61-93-highlights.md
+++ b/artifacts/perf/issue58-61-93-highlights.md
@@ -3,9 +3,9 @@
 - Baseline ref: `a6f60e0ce830c4649ac34fc05e5a1799ec91d151`
 - Current source: working tree
 - Node: `v25.2.0`
-- Selection mode: `scenario-list`
+- Selection mode: `suite`
 - Declared suite: `user-flow`
-- Result-count validation: `3 rows, suite-consistent=true, all-user-flow=true`
+- Result-count validation: `12 rows, suite-consistent=true, all-user-flow=true`
 
 ## Machine Profile
 
@@ -15,7 +15,7 @@
 | Host | OS | Ubuntu 22.04.5 LTS |
 | Host | Kernel | 6.8.0-124-generic |
 | Host | Architecture | x64 |
-| Host | Load Average | 6.83, 6.21, 5.78 |
+| Host | Load Average | 4.9, 4.53, 4.52 |
 | Host | Available Parallelism | - |
 | CPU | Model | Intel(R) Core(TM) i9-14900HX |
 | CPU | Vendor | GenuineIntel |
@@ -23,9 +23,9 @@
 | CPU | Frequency | 800 MHz to 5,800 MHz |
 | CPU | Cache | L1d 384 KiB (8 instances), L1i 256 KiB (8 instances), L2 16 MiB (8 instances), L3 36 MiB (1 instance) |
 | Memory | Total RAM | 62.51 GiB (`67,119,755,264 bytes`) |
-| Memory | Available At Collection | 28.58 GiB (`30,685,663,232 bytes`) |
+| Memory | Available At Collection | 24.29 GiB (`26,085,892,096 bytes`) |
 | Memory | Online Physical RAM | 66.00 GiB (`70,866,960,384 bytes`) |
-| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 83.55 GiB (`89,709,338,624 bytes`) |
+| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 96.88 GiB (`104,022,544,384 bytes`) |
 | Memory | DMI / SPD | Unavailable: /sys/firmware/dmi/tables/smbios_entry_point: Permission denied /dev/mem: Permission denied |
 | Storage | Root Device | nvme0n1 (Samsung SSD 9100 PRO 4TB), 3.64 TiB (`4,000,787,030,016 bytes`), transport nvme, rotational=false, readOnly=false |
 
@@ -33,6 +33,15 @@
 
 | Scenario | Kind | User flow | Measurement scope | Input model |
 | --- | --- | --- | --- | --- |
+| open-file-default-save-rescan-visible-tree | user-flow | Save an already-open file that uses default tag scanning and redraw the visible tree. | Document save listener, document rescan, search-result replacement, and visible-tree render. | Real document text in a VS Code event harness. |
+| open-file-custom-save-rescan-visible-tree | user-flow | Save an already-open file that uses custom regex scanning and redraw the visible tree. | Document save listener, custom-regex document rescan, search-result replacement, and visible-tree render. | Real document text in a VS Code event harness. |
+| tree-view-cycle-visible-tree | user-flow | Cycle the tree between flat, tags-only, and tree views and redraw the visible tree each time. | View-mode commands, workspace-state mutation, and visible-tree rebuild/render. | Fixture workspace tree in a VS Code event harness. |
+| tree-group-toggle-tags-view | user-flow | Toggle tag grouping on and off while in tags view and redraw the visible tree. | Grouping commands, workspace-state mutation, and visible-tree rebuild/render. | Fixture workspace tree in a VS Code event harness. |
+| tree-filter-visible-tree | user-flow | Apply a tree filter and clear it again while the tree is visible. | Filter command handling, tree filtering, and visible-tree render. | Fixture workspace tree in a VS Code event harness. |
+| tree-view-repeat-click-burst | user-flow | Repeatedly click the same view button while the tree state is still mutating. | Overlapping command handling and workspace-state writes. | Command burst against the extension command handlers in a VS Code event harness. |
+| tree-expansion-toggle-visible-tree | user-flow | Expand and then collapse the visible tree. | Expansion commands, workspace-state mutation, and visible-tree rebuild/render. | Fixture workspace tree in a VS Code event harness. |
+| workspace-default-relative-rebuild-visible-tree | user-flow | Trigger a workspace refresh with default tag scanning and rebuild the visible tree from workspace matches. | Workspace refresh orchestration, ripgrep event handling, file reads, result application, and tree rebuild/render. | Fixture ripgrep matches, fixture file contents, and fixture scan results in a VS Code event harness. |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | Trigger a workspace refresh with custom regex scanning and rebuild the visible tree from workspace matches. | Workspace refresh orchestration, ripgrep event handling, regex-match normalization, result application, and tree rebuild/render. | Fixture ripgrep matches, fixture file contents, and fixture normalized regex results in a VS Code event harness. |
 | visible-editor-highlight-open-file | user-flow | Focus or open a visible editor and apply highlights to that editor. | Active-editor event handling, decoration creation/update, and highlight application. | Fixture scan results fed into the real highlight pipeline in a VS Code event harness. |
 | visible-editor-highlight-change-open-file | user-flow | Edit a visible file and refresh its highlights. | Text-change event handling, decoration update, and highlight application. | Fixture scan results fed into the real highlight pipeline in a VS Code event harness. |
 | visible-editor-custom-highlight-config-open-file | user-flow | Open a visible editor while a large custom highlight configuration is active and apply highlights. | Custom-highlight attribute lookup, decoration creation/update, and highlight application. | Fixture scan results plus a large custom-highlight config in a VS Code event harness. |
@@ -49,22 +58,49 @@
 
 | Scenario | Kind | Baseline p50 ms | Current p50 ms | Baseline p90 ms | Current p90 ms | Baseline p95 ms | Current p95 ms |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| visible-editor-highlight-open-file | user-flow | 21.99 | 1.85 | 24.44 | 2.56 | 25.49 | 2.74 |
-| visible-editor-highlight-change-open-file | user-flow | 19.89 | 1.88 | 22.15 | 2.62 | 22.25 | 2.83 |
-| visible-editor-custom-highlight-config-open-file | user-flow | 1892.85 | 2.92 | 1925.68 | 4.26 | 1927.01 | 4.33 |
+| open-file-default-save-rescan-visible-tree | user-flow | 101.5 | 2.02 | 103.83 | 2.35 | 112.72 | 2.88 |
+| open-file-custom-save-rescan-visible-tree | user-flow | 91 | 4.23 | 97.27 | 4.5 | 99.61 | 4.53 |
+| tree-view-cycle-visible-tree | user-flow | 11.47 | 0.36 | 12.56 | 0.49 | 12.92 | 0.54 |
+| tree-group-toggle-tags-view | user-flow | 7.46 | 0.38 | 8.99 | 0.44 | 9.25 | 0.44 |
+| tree-filter-visible-tree | user-flow | 0.41 | 0.35 | 0.52 | 0.51 | 0.53 | 0.75 |
+| tree-view-repeat-click-burst | user-flow | 0.21 | 0.24 | 0.27 | 0.31 | 0.33 | 0.41 |
+| tree-expansion-toggle-visible-tree | user-flow | 7.89 | 0.38 | 8.55 | 0.51 | 8.63 | 0.54 |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 7.44 | 3.78 | 8.79 | 4.4 | 11.03 | 4.47 |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 51.19 | 6.39 | 53.8 | 7.37 | 54.25 | 7.44 |
+| visible-editor-highlight-open-file | user-flow | 19.5 | 1.61 | 20.85 | 2.16 | 21.92 | 2.44 |
+| visible-editor-highlight-change-open-file | user-flow | 19.26 | 1.57 | 21.77 | 2.39 | 22.16 | 2.4 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 1791.22 | 2.55 | 1823.59 | 2.81 | 1832.76 | 4.38 |
 
 ## Profiled RSS Burst
 
 | Scenario | Kind | Baseline p50 MiB | Current p50 MiB | Baseline p90 MiB | Current p90 MiB | Baseline p95 MiB | Current p95 MiB | Baseline Max MiB | Current Max MiB |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| visible-editor-highlight-open-file | user-flow | 47.88 | 14.45 | 49.38 | 14.88 | 49.5 | 15 | 49.5 | 15 |
-| visible-editor-highlight-change-open-file | user-flow | 48 | 14.38 | 49.25 | 14.88 | 49.63 | 15 | 49.63 | 15 |
-| visible-editor-custom-highlight-config-open-file | user-flow | 160.59 | 14.97 | 162.88 | 15.23 | 163.25 | 15.25 | 163.25 | 15.25 |
+| open-file-default-save-rescan-visible-tree | user-flow | 26.13 | 24.25 | 26.75 | 27 | 26.88 | 27.25 | 26.88 | 27.25 |
+| open-file-custom-save-rescan-visible-tree | user-flow | 26.75 | 20.83 | 26.88 | 21.23 | 27.38 | 21.25 | 27.38 | 21.25 |
+| tree-view-cycle-visible-tree | user-flow | 17.25 | 15.48 | 17.63 | 15.83 | 17.88 | 16.25 | 17.88 | 16.25 |
+| tree-group-toggle-tags-view | user-flow | 17 | 15.35 | 17.5 | 15.88 | 17.5 | 16 | 17.5 | 16 |
+| tree-filter-visible-tree | user-flow | 18.75 | 18.75 | 19.25 | 20.5 | 19.38 | 20.88 | 19.38 | 20.88 |
+| tree-view-repeat-click-burst | user-flow | 1.25 | 2.88 | 1.38 | 3 | 1.38 | 3.25 | 1.38 | 3.25 |
+| tree-expansion-toggle-visible-tree | user-flow | 17.25 | 15.5 | 17.75 | 15.85 | 17.88 | 16.13 | 17.88 | 16.13 |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 18.38 | 17.88 | 18.75 | 18.5 | 18.75 | 18.87 | 18.75 | 18.87 |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 79.75 | 23.38 | 88.13 | 30.75 | 88.5 | 31.38 | 88.5 | 31.38 |
+| visible-editor-highlight-open-file | user-flow | 47.75 | 14.46 | 48.88 | 14.75 | 49.25 | 14.75 | 49.25 | 14.75 |
+| visible-editor-highlight-change-open-file | user-flow | 48.5 | 14.38 | 49.63 | 14.82 | 49.63 | 14.88 | 49.63 | 14.88 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 160.13 | 14.85 | 163.13 | 15.08 | 164 | 15.38 | 164 | 15.38 |
 
 ## Profiled Peak RSS
 
 | Scenario | Kind | Baseline p50 RSS MiB | Current p50 RSS MiB | Baseline p90 RSS MiB | Current p90 RSS MiB | Baseline p95 RSS MiB | Current p95 RSS MiB | Baseline Max RSS MiB | Current Max RSS MiB |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| visible-editor-highlight-open-file | user-flow | 104.39 | 71.12 | 105.7 | 71.23 | 106.22 | 71.6 | 106.22 | 71.6 |
-| visible-editor-highlight-change-open-file | user-flow | 104.84 | 70.91 | 105.96 | 71.34 | 106.34 | 71.75 | 106.34 | 71.75 |
-| visible-editor-custom-highlight-config-open-file | user-flow | 217.21 | 71.44 | 219.47 | 71.77 | 220.12 | 71.96 | 220.12 | 71.96 |
+| open-file-default-save-rescan-visible-tree | user-flow | 82.74 | 80.79 | 83.34 | 83.54 | 83.35 | 83.7 | 83.35 | 83.7 |
+| open-file-custom-save-rescan-visible-tree | user-flow | 83.23 | 77.44 | 83.8 | 77.61 | 83.87 | 77.71 | 83.87 | 77.71 |
+| tree-view-cycle-visible-tree | user-flow | 73.63 | 72.18 | 74.13 | 72.51 | 74.32 | 72.89 | 74.32 | 72.89 |
+| tree-group-toggle-tags-view | user-flow | 73.71 | 71.92 | 73.82 | 72.36 | 73.97 | 72.36 | 73.97 | 72.36 |
+| tree-filter-visible-tree | user-flow | 75.4 | 75.5 | 75.8 | 77.07 | 75.82 | 77.51 | 75.82 | 77.51 |
+| tree-view-repeat-click-burst | user-flow | 57.83 | 59.47 | 58 | 59.68 | 58.23 | 60.11 | 58.23 | 60.11 |
+| tree-expansion-toggle-visible-tree | user-flow | 73.79 | 72.19 | 74.38 | 72.54 | 74.54 | 72.55 | 74.54 | 72.55 |
+| workspace-default-relative-rebuild-visible-tree | user-flow | 75.16 | 74.55 | 75.41 | 75.27 | 75.64 | 75.4 | 75.64 | 75.4 |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 136.27 | 80.2 | 144.79 | 87.56 | 145.49 | 87.81 | 145.49 | 87.81 |
+| visible-editor-highlight-open-file | user-flow | 104.43 | 70.95 | 105.53 | 71.28 | 105.93 | 71.32 | 105.93 | 71.32 |
+| visible-editor-highlight-change-open-file | user-flow | 105.1 | 70.99 | 106.07 | 71.6 | 106.22 | 71.61 | 106.22 | 71.61 |
+| visible-editor-custom-highlight-config-open-file | user-flow | 216.79 | 71.43 | 219.57 | 71.66 | 220.41 | 71.93 | 220.41 | 71.93 |

--- a/src/extension.js
+++ b/src/extension.js
@@ -99,9 +99,12 @@ function activate( context )
     var scanProgressSession;
     var scanProgressState;
     var scanStatusBarSpinnerVisible = false;
+    var startupOpenScanRetryTimer;
+    var startupOpenScanRetryIndex = 0;
 
     var SCAN_PROGRESS_MIN_FILE_UNITS = 1;
     var SCAN_DIAGNOSTIC_EVENT_LIMIT = 500;
+    var STARTUP_OPEN_SCAN_RETRY_DELAYS = Object.freeze( [ 50, 150, 350, 750, 1500, 3000 ] );
     var SCAN_PROGRESS_VISIBILITY_BY_MODE = Object.freeze( {
         'none': Object.freeze( { notification: false, statusBar: false, tree: false } ),
         'status bar': Object.freeze( { notification: false, statusBar: true, tree: false } ),
@@ -2546,19 +2549,92 @@ function activate( context )
         return openNotebookTargets;
     }
 
+    function isOpenTextDocumentCandidate( document )
+    {
+        return document &&
+            document.uri &&
+            notebooks.isNotebookCellDocument( document ) !== true &&
+            config.isValidScheme( document.uri );
+    }
+
+    function rememberOpenTextDocument( document )
+    {
+        if( isOpenTextDocumentCandidate( document ) !== true )
+        {
+            return false;
+        }
+
+        openDocuments[ document.uri.toString() ] = document;
+        return true;
+    }
+
+    function rememberVisibleTextEditors()
+    {
+        var remembered = 0;
+
+        vscode.window.visibleTextEditors.forEach( function( editor )
+        {
+            if( editor && editor.document )
+            {
+                if( rememberOpenTextDocument( editor.document ) )
+                {
+                    remembered++;
+                }
+            }
+        } );
+
+        return remembered;
+    }
+
+    function getVisibleTextEditorDocuments()
+    {
+        return vscode.window.visibleTextEditors.map( function( editor )
+        {
+            return editor ? editor.document : undefined;
+        } ).filter( isOpenTextDocumentCandidate );
+    }
+
+    function getWorkspaceTextDocuments()
+    {
+        if( Array.isArray( vscode.workspace.textDocuments ) !== true )
+        {
+            return [];
+        }
+
+        return vscode.workspace.textDocuments.filter( isOpenTextDocumentCandidate );
+    }
+
+    function getOpenTextDocumentCandidates()
+    {
+        var documentsByUri = {};
+
+        Object.keys( openDocuments ).forEach( function( key )
+        {
+            var document = openDocuments[ key ];
+            if( isOpenTextDocumentCandidate( document ) )
+            {
+                documentsByUri[ document.uri.toString() ] = document;
+            }
+        } );
+
+        getWorkspaceTextDocuments().concat( getVisibleTextEditorDocuments() ).forEach( function( document )
+        {
+            documentsByUri[ document.uri.toString() ] = document;
+        } );
+
+        return Object.keys( documentsByUri ).map( function( key )
+        {
+            return documentsByUri[ key ];
+        } ).filter( function( document )
+        {
+            return isIncluded( document.uri );
+        } );
+    }
+
     function getOpenDocumentsForScan( workspaceRoots )
     {
         var scanMode = config.scanMode();
-        var documents = Object.keys( openDocuments ).map( function( key )
-        {
-            return openDocuments[ key ];
-        } ).filter( function( document )
-        {
-            return document &&
-                notebooks.isNotebookCellDocument( document ) !== true &&
-                config.isValidScheme( document.uri ) &&
-                isIncluded( document.uri );
-        } );
+        var documents = getOpenTextDocumentCandidates();
 
         if( scanMode === SCAN_MODE_CURRENT_FILE )
         {
@@ -2584,6 +2660,15 @@ function activate( context )
         }
 
         return [];
+    }
+
+    function scanModeUsesOpenScanTargets()
+    {
+        var scanMode = config.scanMode();
+
+        return scanMode === SCAN_MODE_OPEN_FILES ||
+            scanMode === SCAN_MODE_CURRENT_FILE ||
+            scanMode === SCAN_MODE_WORKSPACE_AND_OPEN_FILES;
     }
 
     function scanNotebookDocument( notebook )
@@ -3209,6 +3294,7 @@ function activate( context )
             flushWorkspaceScanIssues();
             finishScan( generation );
             flushPendingDocumentRefreshes();
+            triggerHighlightsForVisibleEditors();
         } );
     }
 
@@ -3238,6 +3324,57 @@ function activate( context )
 
             executeRebuild();
         }, delay === undefined ? 1000 : delay );
+    }
+
+    function clearStartupOpenScanRetry()
+    {
+        if( startupOpenScanRetryTimer )
+        {
+            clearTimeout( startupOpenScanRetryTimer );
+            startupOpenScanRetryTimer = undefined;
+        }
+    }
+
+    function getOpenScanTargetCount()
+    {
+        if( scanModeUsesOpenScanTargets() !== true )
+        {
+            return 0;
+        }
+
+        return getRefreshTargets( searchList ).length;
+    }
+
+    function scheduleStartupOpenScanRetry()
+    {
+        clearStartupOpenScanRetry();
+
+        if( getOpenScanTargetCount() > 0 || startupOpenScanRetryIndex >= STARTUP_OPEN_SCAN_RETRY_DELAYS.length )
+        {
+            return;
+        }
+
+        var retryDelay = STARTUP_OPEN_SCAN_RETRY_DELAYS[ startupOpenScanRetryIndex ];
+        startupOpenScanRetryIndex++;
+
+        startupOpenScanRetryTimer = setTimeout( function()
+        {
+            startupOpenScanRetryTimer = undefined;
+            rememberVisibleTextEditors();
+
+            if( getOpenScanTargetCount() > 0 )
+            {
+                triggerRescan( 0 );
+                return;
+            }
+
+            scheduleStartupOpenScanRetry();
+        }, retryDelay );
+
+        if( startupOpenScanRetryTimer && typeof startupOpenScanRetryTimer.unref === 'function' && !vscode.env.appName )
+        {
+            startupOpenScanRetryTimer.unref();
+        }
     }
 
     function resetGitWatcher()
@@ -3516,6 +3653,56 @@ function activate( context )
                 return openDocuments[ lookupKey ];
             }
         );
+    }
+
+    function editorMatchesHighlightTarget( editor, document )
+    {
+        if( !editor || !editor.document || config.isValidScheme( editor.document.uri ) !== true )
+        {
+            return false;
+        }
+
+        if( document && document !== editor.document )
+        {
+            return false;
+        }
+
+        return isIncluded( editor.document.uri ) === true;
+    }
+
+    function triggerHighlightsForVisibleEditors( document )
+    {
+        vscode.window.visibleTextEditors.forEach( function( editor )
+        {
+            if( editorMatchesHighlightTarget( editor, document ) )
+            {
+                highlights.triggerHighlight( editor );
+            }
+        } );
+    }
+
+    function documentChanged( document )
+    {
+        if( document )
+        {
+            triggerHighlightsForVisibleEditors( document );
+            if( config.isValidScheme( document.uri ) && path.basename( document.fileName ) !== "settings.json" )
+            {
+                if( notebooks.isNotebookCellDocument( document ) === true )
+                {
+                    return;
+                }
+
+                if( shouldRefreshFile() )
+                {
+                    queueDocumentRefresh( document, 'change' );
+                }
+            }
+        }
+        else
+        {
+            triggerHighlightsForVisibleEditors();
+        }
     }
 
     function refresh( options )
@@ -4042,76 +4229,21 @@ function activate( context )
             return revealPromise;
         }
 
-        function triggerHighlightsForDocument( document )
-        {
-            if( document )
-            {
-                vscode.window.visibleTextEditors.map( editor =>
-                {
-                    if( document === editor.document && config.isValidScheme( document.uri ) )
-                    {
-                        if( isIncluded( document.uri ) )
-                        {
-                            highlights.triggerHighlight( editor );
-                        }
-                    }
-                } );
-            }
-            else
-            {
-                vscode.window.visibleTextEditors.map( editor =>
-                {
-                    if( config.isValidScheme( editor.document.uri ) )
-                    {
-                        if( isIncluded( editor.document.uri ) )
-                        {
-                            highlights.triggerHighlight( editor );
-                        }
-                    }
-                } );
-            }
-        }
-
-        function documentChanged( document )
-        {
-            if( document )
-            {
-                triggerHighlightsForDocument( document );
-                if( config.isValidScheme( document.uri ) && path.basename( document.fileName ) !== "settings.json" )
-                {
-                    if( notebooks.isNotebookCellDocument( document ) === true )
-                    {
-                        return;
-                    }
-
-                    if( shouldRefreshFile() )
-                    {
-                        queueDocumentRefresh( document, 'change' );
-                    }
-                }
-            }
-            else
-            {
-                triggerHighlightsForDocument();
-            }
-        }
-
         function scheduleStartupScan()
         {
             var startupScanImmediate = setImmediate( function()
             {
+                startupOpenScanRetryIndex = 0;
+                rememberVisibleTextEditors();
                 rebuild();
-
-                if( vscode.window.activeTextEditor )
-                {
-                    documentChanged();
-                }
+                scheduleStartupOpenScanRetry();
             } );
 
             context.subscriptions.push( {
                 dispose: function()
                 {
                     clearImmediate( startupScanImmediate );
+                    clearStartupOpenScanRetry();
                 }
             } );
         }
@@ -4129,12 +4261,9 @@ function activate( context )
             var ownerUri = activeNotebook ? activeNotebook.uri : getOwnerUriForDocument( document );
             var ownerFileFilter = ownerUri && ownerUri.fsPath !== undefined ? ownerUri.fsPath : document.fileName;
 
-            triggerHighlightsForDocument( document );
+            triggerHighlightsForVisibleEditors( document );
 
-            if( activeDocumentIsNotebookCell !== true )
-            {
-                openDocuments[ document.uri.toString() ] = document;
-            }
+            rememberOpenTextDocument( document );
 
             if( config.scanMode() === SCAN_MODE_CURRENT_FILE )
             {
@@ -4164,6 +4293,18 @@ function activate( context )
             if( config.scanMode() !== SCAN_MODE_CURRENT_FILE && activeNotebook && shouldRefreshFile() )
             {
                 queueNotebookRefresh( activeNotebook, 'open' );
+            }
+        }
+
+        function visibleTextEditorsChanged()
+        {
+            rememberVisibleTextEditors();
+            triggerHighlightsForVisibleEditors();
+
+            if( shouldRefreshFile() === true && getOpenScanTargetCount() > 0 )
+            {
+                clearStartupOpenScanRetry();
+                triggerRescan( 0 );
             }
         }
 
@@ -4776,6 +4917,10 @@ function activate( context )
         } ) );
 
         context.subscriptions.push( vscode.window.onDidChangeActiveTextEditor( activeEditorChanged ) );
+        if( typeof vscode.window.onDidChangeVisibleTextEditors === 'function' )
+        {
+            context.subscriptions.push( vscode.window.onDidChangeVisibleTextEditors( visibleTextEditorsChanged ) );
+        }
 
         context.subscriptions.push( vscode.workspace.onDidSaveTextDocument( document =>
         {
@@ -4790,11 +4935,10 @@ function activate( context )
 
         context.subscriptions.push( vscode.workspace.onDidOpenTextDocument( document =>
         {
-            if( shouldRefreshFile() )
+            if( config.isValidScheme( document.uri ) && notebooks.isNotebookCellDocument( document ) !== true )
             {
-                if( config.isValidScheme( document.uri ) && notebooks.isNotebookCellDocument( document ) !== true )
+                if( rememberOpenTextDocument( document ) && shouldRefreshFile() )
                 {
-                    openDocuments[ document.uri.toString() ] = document;
                     queueDocumentRefresh( document, 'open' );
                 }
             }
@@ -5016,15 +5160,7 @@ function activate( context )
 
         if( getSetting( 'tree.scanAtStartup', true ) === true )
         {
-            var editors = vscode.window.visibleTextEditors;
-            editors.map( function( editor )
-            {
-                if( editor.document && config.isValidScheme( editor.document.uri ) && notebooks.isNotebookCellDocument( editor.document ) !== true )
-                {
-                    openDocuments[ editor.document.uri.toString() ] = editor.document;
-                }
-            } );
-
+            rememberVisibleTextEditors();
             scheduleStartupScan();
         }
         else

--- a/src/highlights.js
+++ b/src/highlights.js
@@ -10,6 +10,7 @@ var regexRegistry = require( './regexRegistry.js' );
 
 var captureGroupArgument = "capture-groups";
 var themeColourReferenceRegex = regexRegistry.createRegExp( 'themeColourReference', 'i' );
+var defaultEditorHighlightBackground = 'editor.selectionHighlightBackground';
 
 var lanes =
 {
@@ -131,14 +132,12 @@ function createDecoration( tag )
 
     if( lightBackgroundColour === undefined && lightForegroundColour === undefined )
     {
-        lightBackgroundColour = new vscode.ThemeColor( 'editor.foreground' );
-        lightForegroundColour = new vscode.ThemeColor( 'editor.background' );
+        lightBackgroundColour = new vscode.ThemeColor( defaultEditorHighlightBackground );
     }
 
     if( darkBackgroundColour === undefined && darkForegroundColour === undefined )
     {
-        darkBackgroundColour = new vscode.ThemeColor( 'editor.foreground' );
-        darkForegroundColour = new vscode.ThemeColor( 'editor.background' );
+        darkBackgroundColour = new vscode.ThemeColor( defaultEditorHighlightBackground );
     }
 
     var lane = getRulerLane( tag );

--- a/src/highlights.js
+++ b/src/highlights.js
@@ -117,17 +117,17 @@ function createDecoration( tag )
             darkBackgroundColour = new vscode.ThemeColor( 'editor.background' );
         }
 
+        if( lightForegroundColour === undefined && utils.isHexColour( lightBackgroundColour ) )
+        {
+            lightForegroundColour = utils.complementaryColour( lightBackgroundColour );
+        }
+        if( darkForegroundColour === undefined && utils.isHexColour( darkBackgroundColour ) )
+        {
+            darkForegroundColour = utils.complementaryColour( darkBackgroundColour );
+        }
+
         lightBackgroundColour = applyOpacity( lightBackgroundColour, opacity );
         darkBackgroundColour = applyOpacity( darkBackgroundColour, opacity );
-    }
-
-    if( lightForegroundColour === undefined && utils.isHexColour( lightBackgroundColour ) )
-    {
-        lightForegroundColour = utils.complementaryColour( lightBackgroundColour );
-    }
-    if( darkForegroundColour === undefined && utils.isHexColour( darkBackgroundColour ) )
-    {
-        darkForegroundColour = utils.complementaryColour( darkBackgroundColour );
     }
 
     if( lightBackgroundColour === undefined && lightForegroundColour === undefined )

--- a/src/highlights.js
+++ b/src/highlights.js
@@ -258,6 +258,16 @@ function editorId( editor )
 
 function highlight( editor )
 {
+    function addDecorationRange( tag, startPos, endPos )
+    {
+        var decoration = { range: new vscode.Range( startPos, endPos ) };
+        if( documentHighlights[ tag ] === undefined )
+        {
+            documentHighlights[ tag ] = [];
+        }
+        documentHighlights[ tag ].push( decoration );
+    }
+
     function addDecoration( tag, startOffset, endOffset )
     {
         if( startOffset === undefined || endOffset === undefined )
@@ -274,12 +284,30 @@ function highlight( editor )
 
         var startPos = editor.document.positionAt( startOffset );
         var endPos = editor.document.positionAt( endOffset );
-        var decoration = { range: new vscode.Range( startPos, endPos ) };
-        if( documentHighlights[ tag ] === undefined )
+        addDecorationRange( tag, startPos, endPos );
+    }
+
+    function addSingleLineDecoration( tag, startOffset, endOffset )
+    {
+        if( startOffset === undefined || endOffset === undefined )
         {
-            documentHighlights[ tag ] = [];
+            return;
         }
-        documentHighlights[ tag ].push( decoration );
+
+        if( endOffset < startOffset )
+        {
+            var previousStart = startOffset;
+            startOffset = endOffset;
+            endOffset = previousStart;
+        }
+
+        var startPos = editor.document.positionAt( startOffset );
+        var endPos = editor.document.positionAt( endOffset );
+        if( endPos.line !== startPos.line )
+        {
+            endPos = editor.document.lineAt( startPos.line ).range.end;
+        }
+        addDecorationRange( tag, startPos, endPos );
     }
 
     var documentHighlights = {};
@@ -304,7 +332,7 @@ function highlight( editor )
                     }
                     else if( type === 'text' )
                     {
-                        addDecoration( tag, match.matchStartOffset, match.matchEndOffset );
+                        addSingleLineDecoration( tag, match.matchStartOffset, match.matchEndOffset );
                     }
                     else if( type !== undefined && type.indexOf( captureGroupArgument + ":" ) === 0 )
                     {
@@ -341,14 +369,10 @@ function highlight( editor )
                     }
                     else if( type === 'line' || type === 'whole-line' )
                     {
-                        var lineStart = new vscode.Position( editor.document.positionAt( match.commentStartOffset ).line, 0 );
-                        var lineEnd = editor.document.lineAt( editor.document.positionAt( match.commentEndOffset ).line ).range.end;
-                        var lineDecoration = { range: new vscode.Range( lineStart, lineEnd ) };
-                        if( documentHighlights[ tag ] === undefined )
-                        {
-                            documentHighlights[ tag ] = [];
-                        }
-                        documentHighlights[ tag ].push( lineDecoration );
+                        var tagLine = editor.document.positionAt( match.tagStartOffset ).line;
+                        var lineStart = new vscode.Position( tagLine, 0 );
+                        var lineEnd = editor.document.lineAt( tagLine ).range.end;
+                        addDecorationRange( tag, lineStart, lineEnd );
                     }
                     else
                     {

--- a/test/detection.behavior.test.js
+++ b/test/detection.behavior.test.js
@@ -656,4 +656,69 @@ QUnit.module( "behavioral detection", function( hooks )
             [ 'ChangeNote', 'TODO' ]
         );
     } );
+
+    QUnit.test( "issue #61 configured restored-editor tags detect with the default regex", function( assert )
+    {
+        var uri = createUri( '/tmp/issue-61.js' );
+        var tags = [ 'TODO', 'FIXME', 'HACK', 'REVIEW', 'NOTE', 'XXX', 'BUG', '[ ]', '[/]', '[x]' ];
+        var text = tags.map( function( tag )
+        {
+            return '// ' + tag + ' restored editor item';
+        } ).join( '\n' );
+        var config = createConfig( {
+            tagList: tags,
+            caseSensitive: false
+        } );
+
+        utils.init( config );
+
+        assert.deepEqual(
+            detection.scanText( uri, text ).map( function( result ) { return result.actualTag; } ),
+            tags
+        );
+    } );
+
+    QUnit.test( "issue #898 registered custom highlight tags detect through legacy-style regexes", function( assert )
+    {
+        var uri = createUri( '/tmp/issue-898.py' );
+        var tags = [
+            'BUG',
+            'HACK',
+            'FIXME',
+            'TODO',
+            'XXX',
+            '[ ]',
+            '[x]',
+            'NOTE',
+            'ChangeNote',
+            'Change_Note',
+            'CHANGE NOTE',
+            'ToTest'
+        ];
+        var text = tags.map( function( tag )
+        {
+            return '# ' + tag + ' registered custom tag';
+        } ).join( '\n' );
+        var config = createConfig( {
+            tagList: tags,
+            regexSource: slashHashTagRegexWithTail( regexRegistry.fragment( 'anyTextZeroOrMore' ) ),
+            customHighlight: function()
+            {
+                return tags.reduce( function( highlights, tag )
+                {
+                    highlights[ tag ] = {
+                        foreground: '#00C03F'
+                    };
+                    return highlights;
+                }, {} );
+            }
+        } );
+
+        utils.init( config );
+
+        assert.deepEqual(
+            detection.scanText( uri, text ).map( function( result ) { return result.actualTag; } ),
+            tags
+        );
+    } );
 } );

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -796,6 +796,7 @@ function createVscodeStub( options )
                 return Promise.resolve();
             },
             onDidChangeActiveTextEditor: function( listener ) { return registerListener( workspaceListeners, 'activeEditor', listener ); },
+            onDidChangeVisibleTextEditors: function( listener ) { return registerListener( windowListeners, 'visibleTextEditors', listener ); },
             onDidChangeVisibleNotebookEditors: function( listener ) { return registerListener( windowListeners, 'visibleNotebookEditors', listener ); }
         },
         informationMessages: informationMessages,
@@ -803,6 +804,7 @@ function createVscodeStub( options )
         errorMessages: errorMessages,
         workspace: {
             workspaceFolders: options.workspaceFolders || [],
+            textDocuments: options.textDocuments || [],
             registerTextDocumentContentProvider: function()
             {
                 return { dispose: function() {} };
@@ -844,6 +846,7 @@ function createExtensionHarness( options )
     var normalizeCalls = [];
     var normalizeWorkspaceCalls = [];
     var readFileCalls = [];
+    var highlightCalls = [];
     var ripgrepMatchLookup = new Map();
     var validSchemes = options.validSchemes || [ 'file', 'vscode-notebook-cell' ];
     var treeStateOverrides = {};
@@ -1211,7 +1214,10 @@ function createExtensionHarness( options )
         },
         './highlights.js': {
             init: function() {},
-            triggerHighlight: function() {},
+            triggerHighlight: function( editor )
+            {
+                highlightCalls.push( editor );
+            },
             setScanResultsProvider: function() {},
             resetCaches: function() {}
         },
@@ -1404,6 +1410,7 @@ function createExtensionHarness( options )
         normalizeCalls: normalizeCalls,
         normalizeWorkspaceCalls: normalizeWorkspaceCalls,
         readFileCalls: readFileCalls,
+        highlightCalls: highlightCalls,
         notebookMetrics: notebookMetrics,
         vscode: vscodeStub,
         windowListeners: vscodeStub.windowListeners,
@@ -1648,6 +1655,287 @@ QUnit.test( "open-files mode stores canonical document results through the refre
         assert.equal( harness.scanDocumentCalls.length, 1 );
         assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/open.js' );
         assert.deepEqual( harness.provider.replaceCalls[ 0 ].results, fixture );
+    } );
+} );
+
+QUnit.test( "open-files startup scan includes visible editors restored after activation", function( assert )
+{
+    var fixture = [ {
+        uri: matrixHelpers.createUri( '/tmp/restored.js' ),
+        actualTag: 'TODO',
+        displayText: 'restored item',
+        continuationText: []
+    } ];
+    var document = matrixHelpers.createDocument( '/tmp/restored.js', '// TODO restored item' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+    harness.vscode.window.visibleTextEditors = [ { document: document } ];
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/restored.js' );
+        assert.deepEqual( harness.provider.replaceCalls[ 0 ].results, fixture );
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/restored.js' ] );
+    } );
+} );
+
+QUnit.test( "open-files startup scan includes restored workspace text documents before visible editors", function( assert )
+{
+    var fixture = [ {
+        uri: matrixHelpers.createUri( '/tmp/restored-text-document.js' ),
+        actualTag: 'TODO',
+        displayText: 'restored text document item',
+        continuationText: []
+    } ];
+    var document = matrixHelpers.createDocument( '/tmp/restored-text-document.js', '// TODO restored text document item' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        textDocuments: [ document ],
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/restored-text-document.js' );
+        assert.deepEqual( harness.provider.replaceCalls[ 0 ].results, fixture );
+        assert.equal( harness.highlightCalls.length, 0 );
+
+        harness.vscode.window.visibleTextEditors = [ { document: document } ];
+        return harness.vscode.workspaceListeners.activeEditor( { document: document } );
+    } ).then( function()
+    {
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/restored-text-document.js' ] );
+    } );
+} );
+
+QUnit.test( "visible editor readiness event rescans open-files startup after empty scan", function( assert )
+{
+    var fixture = [ {
+        uri: matrixHelpers.createUri( '/tmp/late-visible.js' ),
+        actualTag: 'TODO',
+        displayText: 'late visible item',
+        continuationText: []
+    } ];
+    var document = matrixHelpers.createDocument( '/tmp/late-visible.js', '// TODO late visible item' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 0 );
+
+        harness.vscode.window.visibleTextEditors = [ { document: document } ];
+        harness.vscode.windowListeners.visibleTextEditors( [ { document: document } ] );
+
+        return waitForDelay( 0 ).then( function()
+        {
+            return matrixHelpers.flushAsyncWork();
+        } );
+    } ).then( function()
+    {
+        var lastReplaceCall = harness.provider.replaceCalls[ harness.provider.replaceCalls.length - 1 ];
+
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/late-visible.js' );
+        assert.deepEqual( lastReplaceCall.results, fixture );
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/late-visible.js', '/tmp/late-visible.js' ] );
+    } );
+} );
+
+QUnit.test( "startup open-files retry scans editor that becomes visible after empty scan", function( assert )
+{
+    var scheduledTimeouts = [];
+    var fixture = [ {
+        uri: matrixHelpers.createUri( '/tmp/retry-visible.js' ),
+        actualTag: 'TODO',
+        displayText: 'retry visible item',
+        continuationText: []
+    } ];
+    var document = matrixHelpers.createDocument( '/tmp/retry-visible.js', '// TODO retry visible item' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        documentResults: fixture,
+        timerStubs: {
+            setTimeout: function( callback, delay )
+            {
+                var handle = {
+                    callback: callback,
+                    delay: delay,
+                    unref: function() {}
+                };
+                scheduledTimeouts.push( handle );
+                return handle;
+            },
+            clearTimeout: function() {},
+            setInterval: function() { return {}; },
+            clearInterval: function() {}
+        },
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        var retryTimer = scheduledTimeouts.find( function( timer )
+        {
+            return timer.delay === 50;
+        } );
+
+        assert.equal( harness.scanDocumentCalls.length, 0 );
+        assert.ok( retryTimer );
+
+        harness.vscode.window.visibleTextEditors = [ { document: document } ];
+        retryTimer.callback();
+
+        var rescanTimer = scheduledTimeouts.find( function( timer )
+        {
+            return timer.delay === 0;
+        } );
+
+        assert.ok( rescanTimer );
+        rescanTimer.callback();
+
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        var lastReplaceCall = harness.provider.replaceCalls[ harness.provider.replaceCalls.length - 1 ];
+
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/retry-visible.js' );
+        assert.deepEqual( lastReplaceCall.results, fixture );
+    } );
+} );
+
+QUnit.test( "restored visible editors receive highlights after startup scan without active editor", function( assert )
+{
+    var firstDocument = matrixHelpers.createDocument( '/tmp/first.js', '// TODO first' );
+    var secondDocument = matrixHelpers.createDocument( '/tmp/second.js', '// FIXME second' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [ { document: firstDocument }, { document: secondDocument } ],
+        activeTextEditor: undefined,
+        documentResults: [],
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/first.js', '/tmp/second.js' ] );
+    } );
+} );
+
+QUnit.test( "refresh command reapplies highlights to visible editors", function( assert )
+{
+    var document = matrixHelpers.createDocument( '/tmp/refresh.js', '// TODO refresh' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        scanAtStartup: false,
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [ { document: document } ],
+        documentResults: [],
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.highlightCalls.length, 0 );
+        return harness.vscode.commandHandlers[ 'better-todo-tree.refresh' ]();
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/refresh.js' ] );
+    } );
+} );
+
+QUnit.test( "refresh command scans visible editor when open event was missed", function( assert )
+{
+    var fixture = [ {
+        uri: matrixHelpers.createUri( '/tmp/refresh-visible.js' ),
+        actualTag: 'TODO',
+        displayText: 'refresh visible item',
+        continuationText: []
+    } ];
+    var document = matrixHelpers.createDocument( '/tmp/refresh-visible.js', '// TODO refresh visible item' );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        scanAtStartup: false,
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        textDocuments: [ document ],
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 0 );
+        harness.vscode.window.visibleTextEditors = [ { document: document } ];
+        return harness.vscode.commandHandlers[ 'better-todo-tree.refresh' ]();
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.equal( harness.scanDocumentCalls[ 0 ].fileName, '/tmp/refresh-visible.js' );
+        assert.deepEqual( harness.provider.replaceCalls[ 0 ].results, fixture );
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/refresh-visible.js' ] );
     } );
 } );
 

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -1867,6 +1867,51 @@ QUnit.test( "restored visible editors receive highlights after startup scan with
     } );
 } );
 
+QUnit.test( "issue #61 restored visible editor scans configured custom tag corpus", function( assert )
+{
+    var tags = [ 'TODO', 'FIXME', 'HACK', 'REVIEW', 'NOTE', 'XXX', 'BUG', '[ ]', '[/]', '[x]' ];
+    var document = matrixHelpers.createDocument(
+        '/tmp/issue-61-restored.js',
+        tags.map( function( tag )
+        {
+            return '// ' + tag + ' restored editor item';
+        } ).join( '\n' )
+    );
+    var fixture = tags.map( function( tag, index )
+    {
+        return {
+            uri: document.uri,
+            line: index,
+            actualTag: tag,
+            displayText: 'restored editor item',
+            continuationText: []
+        };
+    } );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: false },
+        visibleTextEditors: [ { document: document } ],
+        activeTextEditor: undefined,
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.deepEqual( harness.provider.replaceCalls[ 0 ].results.map( function( result )
+        {
+            return result.actualTag;
+        } ), tags );
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/issue-61-restored.js' ] );
+    } );
+} );
+
 QUnit.test( "refresh command reapplies highlights to visible editors", function( assert )
 {
     var document = matrixHelpers.createDocument( '/tmp/refresh.js', '// TODO refresh' );
@@ -1936,6 +1981,61 @@ QUnit.test( "refresh command scans visible editor when open event was missed", f
         {
             return editor.document.fileName;
         } ), [ '/tmp/refresh-visible.js' ] );
+    } );
+} );
+
+QUnit.test( "issue #61 refresh command scans configured restored-editor tag corpus", function( assert )
+{
+    var tags = [ 'TODO', 'FIXME', 'HACK', 'REVIEW', 'NOTE', 'XXX', 'BUG', '[ ]', '[/]', '[x]' ];
+    var document = matrixHelpers.createDocument(
+        '/tmp/issue-61-refresh.js',
+        tags.map( function( tag )
+        {
+            return '// ' + tag + ' refresh item';
+        } ).join( '\n' )
+    );
+    var fixture = tags.map( function( tag, index )
+    {
+        return {
+            uri: document.uri,
+            line: index,
+            actualTag: tag,
+            displayText: 'refresh item',
+            continuationText: []
+        };
+    } );
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        scanAtStartup: false,
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: false },
+        visibleTextEditors: [],
+        activeTextEditor: undefined,
+        textDocuments: [ document ],
+        documentResults: fixture,
+        fileContents: {}
+    } );
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 0 );
+        harness.vscode.window.visibleTextEditors = [ { document: document } ];
+        return harness.vscode.commandHandlers[ 'better-todo-tree.refresh' ]();
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        assert.equal( harness.scanDocumentCalls.length, 1 );
+        assert.deepEqual( harness.provider.replaceCalls[ 0 ].results.map( function( result )
+        {
+            return result.actualTag;
+        } ), tags );
+        assert.deepEqual( harness.highlightCalls.map( function( editor )
+        {
+            return editor.document.fileName;
+        } ), [ '/tmp/issue-61-refresh.js' ] );
     } );
 } );
 

--- a/test/highlights.behavior.test.js
+++ b/test/highlights.behavior.test.js
@@ -274,6 +274,135 @@ QUnit.module( "behavioral highlights", function( hooks )
         assert.strictEqual( decoration.dark.color, undefined );
     } );
 
+    QUnit.test( "issue #58 empty colour schemes keep default editor highlights visible", function( assert )
+    {
+        var decorationLog = [];
+        var config = createAttributeConfig( {
+            shouldUseColourScheme: function()
+            {
+                return true;
+            },
+            foregroundColourScheme: function()
+            {
+                return [];
+            },
+            backgroundColourScheme: function()
+            {
+                return [];
+            }
+        } );
+
+        actualUtils.init( config );
+        actualAttributes.init( config );
+
+        var highlights = helpers.loadWithStubs( '../src/highlights.js', {
+            vscode: createVscodeStub( { enabled: true }, decorationLog ),
+            './config.js': {
+                customHighlight: config.customHighlight.bind( config ),
+                subTagRegex: function() { return regexRegistry.pattern( 'subTagPrefixCapture' ); },
+                tagGroup: function() { return undefined; }
+            },
+            './utils.js': actualUtils,
+            './attributes.js': actualAttributes,
+            './icons.js': {
+                getGutterIcon: function()
+                {
+                    return { dark: '/tmp/gutter-dark.svg', light: '/tmp/gutter-light.svg' };
+                }
+            },
+            './detection.js': {
+                scanDocument: function()
+                {
+                    return [];
+                }
+            },
+            './extensionIdentity.js': {
+                getSetting: function( setting, defaultValue )
+                {
+                    return defaultValue;
+                }
+            }
+        } );
+
+        highlights.init( { subscriptions: { push: function() {} } }, function() {} );
+
+        var decoration = highlights.getDecoration( 'TODO' );
+
+        assert.equal( decoration.light.backgroundColor.name, 'editor.selectionHighlightBackground' );
+        assert.equal( decoration.dark.backgroundColor.name, 'editor.selectionHighlightBackground' );
+        assert.strictEqual( decoration.light.color, undefined );
+        assert.strictEqual( decoration.dark.color, undefined );
+    } );
+
+    QUnit.test( "issue #75 identical yellow backgrounds use identical black foregrounds", function( assert )
+    {
+        var decorationLog = [];
+        var config = createAttributeConfig( {
+            tagList: [ 'Bug', 'Temp' ],
+            customHighlight: function()
+            {
+                return {
+                    Bug: {
+                        background: '#ffff00',
+                        iconColour: '#ffff00',
+                        icon: 'bug',
+                        type: 'line'
+                    },
+                    Temp: {
+                        background: '#ffff00',
+                        iconColour: '#ffff00',
+                        icon: 'x',
+                        type: 'line'
+                    }
+                };
+            }
+        } );
+
+        actualUtils.init( config );
+        actualAttributes.init( config );
+
+        var highlights = helpers.loadWithStubs( '../src/highlights.js', {
+            vscode: createVscodeStub( { enabled: true }, decorationLog ),
+            './config.js': {
+                customHighlight: config.customHighlight.bind( config ),
+                subTagRegex: function() { return regexRegistry.pattern( 'subTagPrefixCapture' ); },
+                tagGroup: function() { return undefined; }
+            },
+            './utils.js': actualUtils,
+            './attributes.js': actualAttributes,
+            './icons.js': {
+                getGutterIcon: function()
+                {
+                    return { dark: '/tmp/gutter-dark.svg', light: '/tmp/gutter-light.svg' };
+                }
+            },
+            './detection.js': {
+                scanDocument: function()
+                {
+                    return [];
+                }
+            },
+            './extensionIdentity.js': {
+                getSetting: function( setting, defaultValue )
+                {
+                    return defaultValue;
+                }
+            }
+        } );
+
+        highlights.init( { subscriptions: { push: function() {} } }, function() {} );
+
+        var bugDecoration = highlights.getDecoration( 'Bug' );
+        var tempDecoration = highlights.getDecoration( 'Temp' );
+
+        assert.equal( bugDecoration.light.backgroundColor, 'rgba(255,255,0,1)' );
+        assert.equal( tempDecoration.light.backgroundColor, 'rgba(255,255,0,1)' );
+        assert.equal( bugDecoration.light.color, '#000000' );
+        assert.equal( tempDecoration.light.color, '#000000' );
+        assert.equal( bugDecoration.dark.color, '#000000' );
+        assert.equal( tempDecoration.dark.color, '#000000' );
+    } );
+
     QUnit.test( "customHighlight colours and defaultHighlight fallback flow into editor decorations", function( assert )
     {
         var decorationLog = [];

--- a/test/highlights.behavior.test.js
+++ b/test/highlights.behavior.test.js
@@ -213,6 +213,67 @@ QUnit.module( "behavioral highlights", function( hooks )
         assert.equal( decoration.gutterIconPath, '/tmp/gutter-dark.svg' );
     } );
 
+    QUnit.test( "empty highlight colours use selection highlight background with inherited text colour", function( assert )
+    {
+        var decorationLog = [];
+        var highlights = helpers.loadWithStubs( '../src/highlights.js', {
+            vscode: createVscodeStub( { highlight: 'tag', enabled: true }, decorationLog ),
+            './config.js': {
+                customHighlight: function() { return {}; },
+                subTagRegex: function() { return regexRegistry.pattern( 'subTagPrefixCapture' ); }
+            },
+            './utils.js': {
+                isHexColour: function() { return false; },
+                isRgbColour: function() { return false; },
+                isValidColour: function() { return true; },
+                isThemeColour: function() { return false; },
+                hexToRgba: function( value ) { return value; },
+                complementaryColour: function() { return '#ffffff'; },
+                setRgbAlpha: function( value ) { return value; }
+            },
+            './attributes.js': {
+                getForeground: function() { return undefined; },
+                getBackground: function() { return undefined; },
+                hasCustomHighlight: function() { return false; },
+                getAttribute: function( tag, attribute, defaultValue )
+                {
+                    if( attribute === 'gutterIcon' )
+                    {
+                        return false;
+                    }
+                    return defaultValue;
+                }
+            },
+            './icons.js': {
+                getGutterIcon: function()
+                {
+                    return { dark: '/tmp/gutter-dark.svg', light: '/tmp/gutter-light.svg' };
+                }
+            },
+            './detection.js': {
+                scanDocument: function()
+                {
+                    return [];
+                }
+            },
+            './extensionIdentity.js': {
+                getSetting: function( setting, defaultValue )
+                {
+                    return defaultValue;
+                }
+            }
+        } );
+
+        highlights.init( { subscriptions: { push: function() {} } }, function() {} );
+
+        var decoration = highlights.getDecoration( 'TODO' );
+
+        assert.equal( decoration.light.backgroundColor.name, 'editor.selectionHighlightBackground' );
+        assert.equal( decoration.dark.backgroundColor.name, 'editor.selectionHighlightBackground' );
+        assert.strictEqual( decoration.light.color, undefined );
+        assert.strictEqual( decoration.dark.color, undefined );
+    } );
+
     QUnit.test( "customHighlight colours and defaultHighlight fallback flow into editor decorations", function( assert )
     {
         var decorationLog = [];

--- a/test/highlights.behavior.test.js
+++ b/test/highlights.behavior.test.js
@@ -116,13 +116,34 @@ function createAttributeConfig( overrides )
 {
     return Object.assign( {
         tagList: [ 'TODO', 'FIXME' ],
+        regexSource: actualUtils.DEFAULT_REGEX_SOURCE,
+        caseSensitive: true,
+        multiLine: false,
+        subTagRegexString: regexRegistry.pattern( 'subTagPrefixCapture' ),
         tags: function()
         {
             return this.tagList;
         },
+        regex: function()
+        {
+            return {
+                tags: this.tagList,
+                regex: this.regexSource,
+                caseSensitive: this.caseSensitive,
+                multiLine: this.multiLine
+            };
+        },
+        subTagRegex: function()
+        {
+            return this.subTagRegexString;
+        },
         isRegexCaseSensitive: function()
         {
-            return true;
+            return this.caseSensitive;
+        },
+        shouldGroupByTag: function()
+        {
+            return false;
         },
         shouldUseColourScheme: function()
         {
@@ -145,6 +166,63 @@ function createAttributeConfig( overrides )
             return {};
         }
     }, overrides || {} );
+}
+
+function createActualDetectionHighlightHarness( options )
+{
+    var recorded = [];
+    var decorationLog = [];
+    var config = createAttributeConfig( {
+        tagList: options.tags || [ 'TODO' ],
+        defaultHighlight: function()
+        {
+            return {
+                type: options.type
+            };
+        }
+    } );
+
+    actualUtils.init( config );
+    actualAttributes.init( config );
+
+    var highlights = helpers.loadWithStubs( '../src/highlights.js', {
+        vscode: createVscodeStub( { enabled: true }, decorationLog ),
+        './config.js': {
+            customHighlight: config.customHighlight.bind( config ),
+            subTagRegex: config.subTagRegex.bind( config ),
+            tagGroup: function() { return undefined; }
+        },
+        './utils.js': actualUtils,
+        './attributes.js': actualAttributes,
+        './icons.js': {
+            getGutterIcon: function()
+            {
+                return { dark: '/tmp/gutter.svg', light: '/tmp/gutter.svg' };
+            }
+        },
+        './detection.js': actualDetection,
+        './extensionIdentity.js': {
+            getSetting: function( setting, defaultValue )
+            {
+                return defaultValue;
+            }
+        }
+    } );
+
+    highlights.init( { subscriptions: { push: function() {} } }, function() {} );
+    highlights.highlight( {
+        viewColumn: 1,
+        document: createDocument( options.text ),
+        setDecorations: function( decoration, ranges )
+        {
+            recorded.push( ranges );
+        }
+    } );
+
+    return {
+        recorded: recorded,
+        decorationLog: decorationLog
+    };
 }
 
 QUnit.module( "behavioral highlights", function( hooks )
@@ -705,6 +783,56 @@ QUnit.module( "behavioral highlights", function( hooks )
         assert.equal( recorded[ 0 ][ 0 ].range.start.character, 3 );
         assert.equal( recorded[ 0 ][ 0 ].range.end.line, 0 );
         assert.equal( recorded[ 0 ][ 0 ].range.end.character, 18 );
+    } );
+
+    QUnit.test( "issue #98 text highlights stay on the tag line", function( assert )
+    {
+        var firstLine = '// TODO: this is a todo comment';
+        var harness = createActualDetectionHighlightHarness( {
+            type: 'text',
+            text: [
+                firstLine,
+                '// This is an unrelated comment'
+            ].join( '\n' )
+        } );
+
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.start.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.start.character, 3 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.character, firstLine.length );
+    } );
+
+    QUnit.test( "issue #99 text highlights exclude code on continuation lines", function( assert )
+    {
+        var firstLine = '// TODO: this is highlighted';
+        var harness = createActualDetectionHighlightHarness( {
+            type: 'text',
+            text: [
+                firstLine,
+                'console.log("This code should not be highlighted");  // Extra comment'
+            ].join( '\n' )
+        } );
+
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.start.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.character, firstLine.length );
+    } );
+
+    QUnit.test( "issue #99 line highlights stay on the tag line", function( assert )
+    {
+        var firstLine = '// TODO: this is highlighted';
+        var harness = createActualDetectionHighlightHarness( {
+            type: 'line',
+            text: [
+                firstLine,
+                'console.log("This code should not be highlighted");  // Extra comment'
+            ].join( '\n' )
+        } );
+
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.start.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.start.character, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.line, 0 );
+        assert.equal( harness.recorded[ 0 ][ 0 ].range.end.character, firstLine.length );
     } );
 
     QUnit.test( "issue #888 tag highlights anchor to the content-line asterisk", function( assert )


### PR DESCRIPTION
Repair the visible-editor highlight path so restored editors, manual
refreshes, and open-file scans all use live visible/workspace documents
instead of only documents that emit open or active-editor events.

Open-file scan targets:
- collect scan candidates from tracked open documents, workspace text
  documents, and visible editors
- centralize valid-scheme and notebook-cell filtering before inclusion
  checks
- remember visible editors during startup and active-editor changes
- retry startup open-file scans while VS Code restores visible editors
- cancel pending retry timers once scan targets exist or extension
  disposal runs

Highlight lifecycle:
- move decoration triggering out of nested command setup into shared
  helpers
- reapply highlights after full refresh completion and manual refresh
  commands
- apply highlights for all visible matching editors when no document is
  passed
- listen for visible-editor changes and rescan when restored editors
  appear
- keep document-change refresh queuing aligned with valid non-settings
  text documents

Default highlight contrast:
- use editor.selectionHighlightBackground for empty light/dark highlight
  colours
- inherit editor text colour instead of inverting editor foreground and
  background
- avoid hiding the cursor on default todo-checkbox highlights

Coverage and evidence:
- add scan-parity coverage for restored visible editors, restored
  workspace text documents, visible-editor readiness, startup retry,
  refresh decoration replay, and missed-open refresh scans
- add highlight behavior coverage for empty default colour decoration
  output
- add issue58-61-93 benchmark evidence for visible editor highlight
  flows

Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/58
Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/61
Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/93
Refs:  https://github.com/Gruntfuggly/todo-tree/issues/898
