### PR TITLE
fix: scan config text files without custom patterns

### DIFF
--- a/artifacts/user-smoke/issue101-102-55-62-packaged-vscode/result.md
+++ b/artifacts/user-smoke/issue101-102-55-62-packaged-vscode/result.md
@@ -2,10 +2,11 @@
 
 - vsixPath: <vsix>
 - codePath: code
-- scenarioCount: 2
-- totalElapsedMs: 14814
+- scenarioCount: 3
+- totalElapsedMs: 22163
 
 | scenario | expected items | found items | expected raw matches | raw matches | scan issues | scan ms | elapsed ms | process rows |
 | --- | ---: | --- | ---: | --- | ---: | ---: | ---: | ---: |
-| explicit_include_dotfiles | 4 | 4 | 4 | 4 | 0 | 53 | 3004 | 7 |
-| hidden_permission_recovery | 4 | 4 | 5 | 5 | 1 | 41 | 3003 | 7 |
+| default_text_scan_hidden_files | 12 | 12 | 20 | 20 | 0 | 72 | 3004 | 7 |
+| explicit_include_dotfiles | 8 | 8 | 8 | 8 | 0 | 41 | 3002 | 7 |
+| hidden_permission_recovery | 8 | 8 | 16 | 16 | 1 | 51 | 3003 | 7 |

--- a/scripts/repro/issue101-102-55-62-vscode-smoke.js
+++ b/scripts/repro/issue101-102-55-62-vscode-smoke.js
@@ -7,9 +7,13 @@ const regexRegistry = require('../../src/regexRegistry.js');
 
 const DEFAULT_WAIT_MS = 30000;
 const POLL_MS = 1000;
-const EXPECTED_FILES = [
-    './.env',
-    './.env.example',
+const ISSUE_INCLUDE_GLOBS = [
+    '**/*.json',
+    '**/*.jsonc',
+    '**/.env',
+    '**/.env*'
+];
+const EXPECTED_PREVIEW_FILES = [
     './config/settings.json',
     './config/settings.jsonc'
 ];
@@ -210,53 +214,29 @@ function splitLines(text) {
     return text.split(lineBreakRegex).filter((line) => line.length > 0);
 }
 
-function createSettings(includeHiddenFiles) {
+function createSettings(options) {
     return {
         'better-todo-tree.general.debug': true,
         'better-todo-tree.general.tags': [
-            'NOTE'
+            'NOTE',
+            'TODO',
+            'BUG',
+            'HACK',
+            'FIXME',
+            'XXX',
+            '[ ]',
+            '[x]'
         ],
         'better-todo-tree.tree.scanAtStartup': true,
         'better-todo-tree.tree.scanMode': 'workspace',
         'better-todo-tree.tree.showCountsInTree': true,
-        'better-todo-tree.filtering.includeHiddenFiles': includeHiddenFiles,
-        'better-todo-tree.filtering.includeGlobs': [
-            '**/*.json',
-            '**/*.jsonc',
-            '**/.env',
-            '**/.env*'
-        ],
+        'better-todo-tree.filtering.includeHiddenFiles': options.includeHiddenFiles,
+        'better-todo-tree.filtering.includeGlobs': options.includeGlobs,
         'better-todo-tree.filtering.excludeGlobs': [],
         'better-todo-tree.filtering.passGlobsToRipgrep': true,
         'better-todo-tree.filtering.useBuiltInExcludes': 'none',
-        'better-todo-tree.languages.customPatterns': [
-            {
-                id: 'issue-json-comments',
-                extensions: [
-                    '.json',
-                    '.jsonc'
-                ],
-                singleLineComments: [
-                    '//'
-                ]
-            },
-            {
-                id: 'issue-dotenv-comments',
-                filenames: [
-                    '.env',
-                    '.env.example'
-                ],
-                filenameGlobs: [
-                    '**/.env',
-                    '**/.env*'
-                ],
-                singleLineComments: [
-                    '#'
-                ]
-            }
-        ],
         'better-todo-tree.ripgrep.usePatternFile': true,
-        'better-todo-tree.ripgrep.ripgrepArgs': '--no-config',
+        'better-todo-tree.ripgrep.ripgrepArgs': '--no-config --no-ignore-parent',
         'better-todo-tree.general.periodicRefreshInterval': 0,
         'better-todo-tree.general.automaticGitRefreshInterval': 0,
         'security.workspace.trust.enabled': false,
@@ -268,20 +248,38 @@ function createSettings(includeHiddenFiles) {
     };
 }
 
-function createWorkspace(workspacePath, includeHiddenFiles, deniedDirectory) {
+function createWorkspace(workspacePath, scenario) {
     fs.rmSync(workspacePath, {
         recursive: true,
         force: true
     });
 
-    writeJson(path.join(workspacePath, '.vscode', 'settings.json'), createSettings(includeHiddenFiles));
+    writeJson(path.join(workspacePath, '.vscode', 'settings.json'), createSettings(scenario));
     writeText(path.join(workspacePath, '.env'), '# NOTE env item\n');
     writeText(path.join(workspacePath, '.env.example'), '# NOTE env example\n');
-    writeText(path.join(workspacePath, 'config', 'settings.json'), '// NOTE json item\n');
-    writeText(path.join(workspacePath, 'config', 'settings.jsonc'), '// NOTE jsonc item\n');
+    writeText(path.join(workspacePath, 'config', 'settings.json'), [
+        '[',
+        '  // NOTE: this is a test',
+        '  {',
+        '    "name": "test"',
+        '  },',
+        '  // [ ] for @amorenojr: testing',
+        '  // [x] for @amorenojr: testing',
+        ']',
+        ''
+    ].join('\n'));
+    writeText(path.join(workspacePath, 'config', 'settings.jsonc'), [
+        '// NOTE: this is a jsonc test',
+        '// [ ] for @amorenojr: jsonc',
+        '// [x] for @amorenojr: jsonc',
+        ''
+    ].join('\n'));
     writeText(path.join(workspacePath, 'src', 'source.py'), '# NOTE source control item\n');
+    writeText(path.join(workspacePath, 'src', 'app.cs'), '// HACK csharp item\n');
+    writeText(path.join(workspacePath, 'src', 'view.xml'), '<!-- XXX xml item -->\n');
+    writeText(path.join(workspacePath, 'notes.txt'), 'TODO text item\n');
 
-    if (deniedDirectory === true) {
+    if (scenario.deniedDirectory === true) {
         const deniedPath = path.join(workspacePath, '.denied');
         writeText(path.join(deniedPath, 'blocked.json'), '// NOTE denied item\n');
         fs.chmodSync(deniedPath, 0);
@@ -302,7 +300,10 @@ function installVsix(args, scenarioDir) {
 
     mkdirp(path.join(userDataDir, 'User'));
     mkdirp(extensionsDir);
-    writeJson(path.join(userDataDir, 'User', 'settings.json'), createSettings(false));
+    writeJson(path.join(userDataDir, 'User', 'settings.json'), createSettings({
+        includeHiddenFiles: false,
+        includeGlobs: []
+    }));
 
     const install = runCommand(args.codePath, [
         '--user-data-dir',
@@ -497,7 +498,7 @@ function summarizeScenario(name, scenario, install, parsedLog, runtime, killedPi
         name,
         expectedItemCount: scenario.expectedItemCount,
         expectedSearchMatchCount: scenario.expectedSearchMatchCount,
-        expectedFiles: EXPECTED_FILES,
+        expectedPreviewFiles: scenario.expectedPreviewFiles || EXPECTED_PREVIEW_FILES,
         installed: install.installed,
         outputLogCount: parsedLog.outputLogCount,
         foundItemCounts: parsedLog.foundItemCounts,
@@ -514,10 +515,10 @@ function summarizeScenario(name, scenario, install, parsedLog, runtime, killedPi
     };
 }
 
-function assertIncludesAllPaths(result) {
+function assertIncludesAllPaths(result, scenario) {
     const pathSet = new Set(result.rawPaths);
 
-    EXPECTED_FILES.forEach((filePath) => {
+    (scenario.expectedPreviewFiles || EXPECTED_PREVIEW_FILES).forEach((filePath) => {
         if (pathSet.has(filePath) !== true) {
             throw new Error(`${result.name} missing raw match path ${filePath}`);
         }
@@ -546,7 +547,7 @@ function assertScenario(result, scenario) {
     }
 
     if (scenario.assertPreviewPaths !== false) {
-        assertIncludesAllPaths(result);
+        assertIncludesAllPaths(result, scenario);
     }
 
     if (result.statusHasExtensionHost !== true && result.outputLogCount === 0) {
@@ -596,7 +597,7 @@ async function runScenario(args, rootOutDir, name, scenario, redactor) {
         force: true
     });
     mkdirp(scenarioDir);
-    createWorkspace(workspacePath, scenario.includeHiddenFiles, scenario.deniedDirectory);
+    createWorkspace(workspacePath, scenario);
 
     const install = installVsix(args, scenarioDir);
 
@@ -689,19 +690,30 @@ async function main() {
     const rootOutDir = path.resolve(args.outDir);
     const startedAt = Date.now();
     const scenarios = {
+        default_text_scan_hidden_files: {
+            includeHiddenFiles: true,
+            includeGlobs: [],
+            deniedDirectory: false,
+            expectedItemCount: 12,
+            expectedSearchMatchCount: 20,
+            expectRecoverableIssue: false,
+            assertPreviewPaths: false
+        },
         explicit_include_dotfiles: {
             includeHiddenFiles: false,
+            includeGlobs: ISSUE_INCLUDE_GLOBS,
             deniedDirectory: false,
-            expectedItemCount: 4,
-            expectedSearchMatchCount: 4,
+            expectedItemCount: 8,
+            expectedSearchMatchCount: 8,
             expectRecoverableIssue: false,
-            assertPreviewPaths: true
+            assertPreviewPaths: false
         },
         hidden_permission_recovery: {
             includeHiddenFiles: true,
+            includeGlobs: ISSUE_INCLUDE_GLOBS,
             deniedDirectory: true,
-            expectedItemCount: 4,
-            expectedSearchMatchCount: 5,
+            expectedItemCount: 8,
+            expectedSearchMatchCount: 16,
             expectRecoverableIssue: true,
             assertPreviewPaths: false
         }

--- a/src/detection.js
+++ b/src/detection.js
@@ -927,6 +927,14 @@ function collectCommentPatternMatches( uri, text, pattern, lineOffsets, resource
     return results;
 }
 
+function hasCommentPatternTokens( pattern )
+{
+    return pattern !== undefined && (
+        ( Array.isArray( pattern.singleLineComment ) && pattern.singleLineComment.length > 0 ) ||
+        ( Array.isArray( pattern.multiLineComment ) && pattern.multiLineComment.length > 0 )
+    );
+}
+
 function resolveMarkdownCommentPattern()
 {
     var markdownCommentPattern = utils.resolveBlockCommentPattern( '.md' ).pattern;
@@ -1345,6 +1353,10 @@ function scanCommentPatternText( uri, text, resourceConfig, patternFileName, opt
         {
             results = [];
         }
+    }
+    else if( options.skipEmbeddedDocuments !== true && hasCommentPatternTokens( pattern ) !== true )
+    {
+        results = runRegexScan( context );
     }
     else
     {

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -3053,51 +3053,63 @@ QUnit.test( "issue #87 workspace scan keeps included child folder under excluded
     } );
 } );
 
-QUnit.test( "issue #101 workspace includeGlobs scan detects custom JSON and dotenv text", function( assert )
-{
-    var jsonPath = '/workspace/config/settings.json';
-    var envPath = '/workspace/.env';
-    var harness;
+var ISSUE101_TAGS = [ 'NOTE', 'TODO', 'BUG', 'HACK', 'FIXME', 'XXX', '[ ]', '[x]' ];
+var ISSUE101_FILE_CONTENTS = {
+    '/workspace/.env': '# NOTE env item\n# [ ] env checkbox',
+    '/workspace/.env.example': '# TODO env example',
+    '/workspace/config/settings.json': [
+        '[',
+        '    // NOTE: this is a test',
+        '    {',
+        '        "name": "test"',
+        '    },',
+        '    // [ ] for @amorenojr: testing',
+        '    // [x] for @amorenojr: testing',
+        ']'
+    ].join( '\n' ),
+    '/workspace/config/settings.jsonc': '// BUG jsonc bug',
+    '/workspace/src/source.py': '# FIXME python item',
+    '/workspace/src/app.cs': '// HACK csharp item',
+    '/workspace/src/view.xml': '<!-- XXX xml item -->',
+    '/workspace/notes.txt': 'NOTE text item'
+};
+var ISSUE101_EXPECTED_RESULTS = {
+    '/workspace/.env': [ [ 'NOTE', 'env item' ], [ '[ ]', 'env checkbox' ] ],
+    '/workspace/.env.example': [ [ 'TODO', 'env example' ] ],
+    '/workspace/config/settings.json': [
+        [ 'NOTE', ': this is a test' ],
+        [ '[ ]', 'for @amorenojr: testing' ],
+        [ '[x]', 'for @amorenojr: testing' ]
+    ],
+    '/workspace/config/settings.jsonc': [ [ 'BUG', 'jsonc bug' ] ],
+    '/workspace/src/source.py': [ [ 'FIXME', 'python item' ] ],
+    '/workspace/src/app.cs': [ [ 'HACK', 'csharp item' ] ],
+    '/workspace/src/view.xml': [ [ 'XXX', 'xml item -->' ] ],
+    '/workspace/notes.txt': [ [ 'NOTE', 'text item' ] ]
+};
 
+function assertIssue101WorkspaceScan( assert, filteringOverrides, expectedGlobs, expectedPaths )
+{
     actualUtils.init( matrixHelpers.createConfig( {
-        tagList: [ 'NOTE' ],
-        customCommentPatterns: function()
-        {
-            return [
-                {
-                    id: 'issue101json',
-                    extensions: [ '.json' ],
-                    singleLineComments: [ '//' ]
-                },
-                {
-                    id: 'issue101dotenv',
-                    filenames: [ '.env', '.env.example' ],
-                    filenameGlobs: [ '**/.env*' ],
-                    singleLineComments: [ '#' ]
-                }
-            ];
-        },
-        customEmbeddedDocuments: function()
-        {
-            return [];
-        }
+        tagList: ISSUE101_TAGS
     } ) );
 
-    harness = createExtensionHarness( {
+    var harness = createExtensionHarness( {
         scanMode: 'workspace',
-        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
-        filteringOverrides: {
-            includeGlobs: [ '**/*.json', '**/.env', '**/.env*' ]
+        tags: ISSUE101_TAGS,
+        resourceConfig: {
+            isDefaultRegex: true,
+            enableMultiLine: false,
+            regexCaseSensitive: true,
+            tagList: ISSUE101_TAGS
         },
+        filteringOverrides: filteringOverrides,
         workspaceFolders: [ { uri: matrixHelpers.createUri( '/workspace' ), name: 'workspace' } ],
-        ripgrepMatches: [
-            { fsPath: jsonPath },
-            { fsPath: envPath }
-        ],
-        fileContents: {
-            '/workspace/config/settings.json': '// NOTE json item',
-            '/workspace/.env': '# NOTE dotenv item'
-        },
+        ripgrepMatches: expectedPaths.map( function( fsPath )
+        {
+            return { fsPath: fsPath };
+        } ),
+        fileContents: ISSUE101_FILE_CONTENTS,
         scanTextWithStreamingImpl: function( context )
         {
             return actualDetection.scanTextWithStreamingContext(
@@ -3110,72 +3122,95 @@ QUnit.test( "issue #101 workspace includeGlobs scan detects custom JSON and dote
 
     return matrixHelpers.flushAsyncWork().then( function()
     {
-        var jsonResults = getLatestReplaceCallForPath( harness, jsonPath ).results;
-        var envResults = getLatestReplaceCallForPath( harness, envPath ).results;
-
         assert.equal( harness.ripgrepSearchCalls.length, 1 );
-        assert.equal( actualUtils.isHidden( envPath ), true );
-        assert.deepEqual( harness.ripgrepSearchCalls[ 0 ].globs, [
+        assert.equal( actualUtils.isHidden( '/workspace/.env' ), true );
+        assert.equal( actualUtils.isHidden( '/workspace/.env.example' ), false );
+        assert.deepEqual( harness.ripgrepSearchCalls[ 0 ].globs, expectedGlobs );
+        assert.deepEqual( harness.readFileCalls.sort(), expectedPaths.slice().sort() );
+        expectedPaths.forEach( function( fsPath )
+        {
+            assert.deepEqual(
+                getLatestReplaceCallForPath( harness, fsPath ).results.map( function( result )
+                {
+                    return [ result.actualTag, result.displayText ];
+                } ),
+                ISSUE101_EXPECTED_RESULTS[ fsPath ],
+                fsPath
+            );
+        } );
+    } );
+}
+
+QUnit.test( "issue #101 workspace scan detects config data and source text without custom language settings", function( assert )
+{
+    var paths = Object.keys( ISSUE101_FILE_CONTENTS );
+
+    return assertIssue101WorkspaceScan(
+        assert,
+        { includeHiddenFiles: true, includeGlobs: [] },
+        [ '!**/node_modules/*/**' ],
+        paths
+    );
+} );
+
+QUnit.test( "issue #101 workspace includeGlobs scan detects config data without custom language settings", function( assert )
+{
+    var paths = [
+        '/workspace/.env',
+        '/workspace/.env.example',
+        '/workspace/config/settings.json',
+        '/workspace/config/settings.jsonc'
+    ];
+
+    return assertIssue101WorkspaceScan(
+        assert,
+        { includeGlobs: [ '**/*.json', '**/*.jsonc', '**/.env', '**/.env*' ] },
+        [
             '**/*.json',
+            '**/*.jsonc',
             '**/.env',
             '**/.env*',
             '!**/node_modules/*/**'
-        ] );
-        assert.deepEqual( harness.readFileCalls.sort(), [ envPath, jsonPath ].sort() );
-        assert.deepEqual(
-            jsonResults.map( function( result )
-            {
-                return [ result.actualTag, result.displayText ];
-            } ),
-            [ [ 'NOTE', 'json item' ] ]
-        );
-        assert.deepEqual(
-            envResults.map( function( result )
-            {
-                return [ result.actualTag, result.displayText ];
-            } ),
-            [ [ 'NOTE', 'dotenv item' ] ]
-        );
-    } );
+        ],
+        paths
+    );
 } );
 
-QUnit.test( "issue #102 workspace includeGlobs scan detects JSON with hidden files enabled", function( assert )
+function assertIssue102JsonWorkspaceScan( assert, filteringOverrides, expectedGlobs )
 {
     var jsonPath = '/workspace/config/settings.json';
     var jsoncPath = '/workspace/config/settings.jsonc';
 
     actualUtils.init( matrixHelpers.createConfig( {
-        tagList: [ 'NOTE' ],
-        customCommentPatterns: function()
-        {
-            return [ {
-                id: 'issue102json',
-                extensions: [ '.json', '.jsonc' ],
-                singleLineComments: [ '//' ]
-            } ];
-        },
-        customEmbeddedDocuments: function()
-        {
-            return [];
-        }
+        tagList: [ 'NOTE', '[ ]', '[x]' ]
     } ) );
 
     var harness = createExtensionHarness( {
         scanMode: 'workspace',
-        tags: [ 'NOTE' ],
+        tags: [ 'NOTE', '[ ]', '[x]' ],
         resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
-        filteringOverrides: {
-            includeHiddenFiles: true,
-            includeGlobs: [ '**/*.json', '**/*.jsonc' ]
-        },
+        filteringOverrides: filteringOverrides,
         workspaceFolders: [ { uri: matrixHelpers.createUri( '/workspace' ), name: 'workspace' } ],
         ripgrepMatches: [
             { fsPath: jsonPath },
             { fsPath: jsoncPath }
         ],
         fileContents: {
-            '/workspace/config/settings.json': '// NOTE json item',
-            '/workspace/config/settings.jsonc': '// NOTE jsonc item'
+            '/workspace/config/settings.json': [
+                '[',
+                '    // NOTE: this is a test',
+                '    {',
+                '        "name": "test"',
+                '    },',
+                '    // [ ] for @amorenojr: testing',
+                '    // [x] for @amorenojr: testing',
+                ']'
+            ].join( '\n' ),
+            '/workspace/config/settings.jsonc': [
+                '// NOTE: this is a jsonc test',
+                '// [ ] for @amorenojr: jsonc',
+                '// [x] for @amorenojr: jsonc'
+            ].join( '\n' )
         },
         scanTextWithStreamingImpl: function( context )
         {
@@ -3192,27 +3227,53 @@ QUnit.test( "issue #102 workspace includeGlobs scan detects JSON with hidden fil
         var jsonResults = getLatestReplaceCallForPath( harness, jsonPath ).results;
         var jsoncResults = getLatestReplaceCallForPath( harness, jsoncPath ).results;
 
-        assert.deepEqual( harness.ripgrepSearchCalls[ 0 ].globs, [
-            '**/*.json',
-            '**/*.jsonc',
-            '!**/node_modules/*/**'
-        ] );
+        assert.deepEqual( harness.ripgrepSearchCalls[ 0 ].globs, expectedGlobs );
         assert.deepEqual( harness.readFileCalls.sort(), [ jsonPath, jsoncPath ].sort() );
         assert.deepEqual(
             jsonResults.map( function( result )
             {
                 return [ result.actualTag, result.displayText ];
             } ),
-            [ [ 'NOTE', 'json item' ] ]
+            [
+                [ 'NOTE', ': this is a test' ],
+                [ '[ ]', 'for @amorenojr: testing' ],
+                [ '[x]', 'for @amorenojr: testing' ]
+            ]
         );
         assert.deepEqual(
             jsoncResults.map( function( result )
             {
                 return [ result.actualTag, result.displayText ];
             } ),
-            [ [ 'NOTE', 'jsonc item' ] ]
+            [
+                [ 'NOTE', ': this is a jsonc test' ],
+                [ '[ ]', 'for @amorenojr: jsonc' ],
+                [ '[x]', 'for @amorenojr: jsonc' ]
+            ]
         );
     } );
+}
+
+QUnit.test( "issue #102 workspace scan detects JSON comments without custom language settings", function( assert )
+{
+    return assertIssue102JsonWorkspaceScan(
+        assert,
+        { includeHiddenFiles: true, includeGlobs: [] },
+        [ '!**/node_modules/*/**' ]
+    );
+} );
+
+QUnit.test( "issue #102 workspace includeGlobs scan detects JSON comments without custom language settings", function( assert )
+{
+    return assertIssue102JsonWorkspaceScan(
+        assert,
+        { includeHiddenFiles: true, includeGlobs: [ '**/*.json', '**/*.jsonc' ] },
+        [
+            '**/*.json',
+            '**/*.jsonc',
+            '!**/node_modules/*/**'
+        ]
+    );
 } );
 
 QUnit.test( "workspace includeGlobs scan detects Svelte and Astro embedded TODOs", function( assert )

--- a/test/matrixHelpers.js
+++ b/test/matrixHelpers.js
@@ -387,6 +387,31 @@ TestTextBuilder.prototype.addSingleLineCase = function( token, tag, description 
     } );
 };
 
+TestTextBuilder.prototype.addRegexFallbackLineCase = function( token, tag, description )
+{
+    var line = token + ' ' + tag + ' ' + description;
+    var record = this.addLine( line );
+    var tagStartOffset = record.startOffset + token.length + 1;
+
+    this.expectations.push( {
+        actualTag: tag,
+        displayText: description,
+        continuationText: [],
+        before: token,
+        after: description,
+        line: record.lineNumber,
+        column: token.length + 2,
+        endLine: record.lineNumber,
+        endColumn: record.text.length + 1,
+        commentStartOffset: record.startOffset,
+        commentEndOffset: record.startOffset + record.text.length,
+        matchStartOffset: tagStartOffset,
+        matchEndOffset: record.startOffset + record.text.length,
+        tagStartOffset: tagStartOffset,
+        tagEndOffset: tagStartOffset + tag.length
+    } );
+};
+
 TestTextBuilder.prototype.addSingleLineBlockCase = function( token, tag, description, continuation )
 {
     var firstLine = this.addLine( token + ' ' + tag + ' ' + description );
@@ -528,6 +553,15 @@ function buildNegativeText( language )
         ].join( '\n' );
     }
 
+    if( language.singleLineTokens.length === 0 && language.multiLineEntries.length === 0 )
+    {
+        return [
+            'Plain TODO text',
+            'Plain HACK text',
+            '"TODO": "plain data"'
+        ].join( '\n' );
+    }
+
     return [
         'TODO plain text',
         'HACK plain text',
@@ -555,9 +589,14 @@ function buildLanguageScenario( language )
 
     if( language.singleLineTokens.length === 0 && language.multiLineEntries.length === 0 )
     {
+        defaultTags.forEach( function( tag )
+        {
+            builder.addRegexFallbackLineCase( '//', tag, slug + '-' + tagLabel( tag ) + '-regex-fallback-0' );
+        } );
+
         return {
-            text: "",
-            expectations: [],
+            text: builder.toText(),
+            expectations: builder.expectations,
             negativeText: buildNegativeText( language )
         };
     }


### PR DESCRIPTION
Fall back to the default regex when resolved language metadata has no comment delimiters, so config/data text still uses the configured tag regex.

Detection:
- scan top-level no-token language matches through the default regex path
- keep embedded JSON script regions commentless during compound-document scans

Coverage:
- replace custom-pattern issue #101/#102 tests with default-setting cases
- cover JSON, JSONC, dotenv, source, XML, and plain text workspace scans
- refresh packaged VS Code smoke for default scans, explicit includes, and hidden traversal recovery

Refs: https://github.com/FanaticPythoner/better-todo-tree/issues/101
Refs: https://github.com/FanaticPythoner/better-todo-tree/issues/102