### PR TITLE
fix: swap tree expansion title icons by expanded state

### DIFF
--- a/artifacts/perf/issue59-title-expansion-icon.md
+++ b/artifacts/perf/issue59-title-expansion-icon.md
@@ -1,0 +1,62 @@
+# Runtime Benchmarks
+
+- Baseline ref: `a6f60e0ce830c4649ac34fc05e5a1799ec91d151`
+- Current source: working tree
+- Node: `v25.2.0`
+- Selection mode: `scenario-list`
+- Declared suite: `user-flow`
+- Result-count validation: `1 rows, suite-consistent=true, all-user-flow=true`
+
+## Machine Profile
+
+| Category | Field | Value |
+| --- | --- | --- |
+| Host | Hostname | n00ne-AERO-17-YD |
+| Host | OS | Ubuntu 22.04.5 LTS |
+| Host | Kernel | 6.8.0-124-generic |
+| Host | Architecture | x64 |
+| Host | Load Average | 5.77, 5.1, 5.17 |
+| Host | Available Parallelism | - |
+| CPU | Model | Intel(R) Core(TM) i9-14900HX |
+| CPU | Vendor | GenuineIntel |
+| CPU | Topology | 16 logical CPU(s), 2 thread(s)/core, 8 core(s)/socket, 1 socket(s), 1 NUMA node(s) |
+| CPU | Frequency | 800 MHz to 5,800 MHz |
+| CPU | Cache | L1d 384 KiB (8 instances), L1i 256 KiB (8 instances), L2 16 MiB (8 instances), L3 36 MiB (1 instance) |
+| Memory | Total RAM | 62.51 GiB (`67,119,755,264 bytes`) |
+| Memory | Available At Collection | 25.20 GiB (`27,057,074,176 bytes`) |
+| Memory | Online Physical RAM | 66.00 GiB (`70,866,960,384 bytes`) |
+| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 88.00 GiB (`94,486,458,368 bytes`) |
+| Memory | DMI / SPD | Unavailable: /sys/firmware/dmi/tables/smbios_entry_point: Permission denied /dev/mem: Permission denied |
+| Storage | Root Device | nvme0n1 (Samsung SSD 9100 PRO 4TB), 3.64 TiB (`4,000,787,030,016 bytes`), transport nvme, rotational=false, readOnly=false |
+
+## Scenario Model
+
+| Scenario | Kind | User flow | Measurement scope | Input model |
+| --- | --- | --- | --- | --- |
+| tree-expansion-toggle-visible-tree | user-flow | Expand and then collapse the visible tree. | Expansion commands, workspace-state mutation, and visible-tree rebuild/render. | Fixture workspace tree in a VS Code event harness. |
+
+## Metric Model
+
+| Table | Value model | Accuracy model |
+| --- | --- | --- |
+| Latency | Wall-clock elapsed time around each harness flow iteration, summarized as min/p50/p90/p95/max. | Exact for each sampled iteration in this run. |
+| Profiled RSS Burst | Difference between the isolated scenario worker RSS measured immediately before the flow and that worker iteration's OS high-water-mark peak RSS. | Exact for the measured worker iteration, using `process.memoryUsage().rss` at flow start and `process.resourceUsage().maxRSS` for the peak. |
+| Profiled Peak RSS | Highest process RSS reached by each isolated scenario worker iteration. | Exact worker-process high-water mark from `process.resourceUsage().maxRSS`. |
+
+## Latency
+
+| Scenario | Kind | Baseline p50 ms | Current p50 ms | Baseline p90 ms | Current p90 ms | Baseline p95 ms | Current p95 ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| tree-expansion-toggle-visible-tree | user-flow | 9.12 | 0.44 | 11.81 | 0.67 | 14.65 | 0.69 |
+
+## Profiled RSS Burst
+
+| Scenario | Kind | Baseline p50 MiB | Current p50 MiB | Baseline p90 MiB | Current p90 MiB | Baseline p95 MiB | Current p95 MiB | Baseline Max MiB | Current Max MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| tree-expansion-toggle-visible-tree | user-flow | 17 | 10.25 | 17.63 | 10.63 | 17.88 | 10.63 | 17.88 | 10.63 |
+
+## Profiled Peak RSS
+
+| Scenario | Kind | Baseline p50 RSS MiB | Current p50 RSS MiB | Baseline p90 RSS MiB | Current p90 RSS MiB | Baseline p95 RSS MiB | Current p95 RSS MiB | Baseline Max RSS MiB | Current Max RSS MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| tree-expansion-toggle-visible-tree | user-flow | 73.52 | 66.91 | 73.83 | 67.04 | 74.02 | 67.23 | 74.02 | 67.23 |

--- a/artifacts/user-smoke/issue59-vscode-install.md
+++ b/artifacts/user-smoke/issue59-vscode-install.md
@@ -1,0 +1,30 @@
+# Issue 59 VS Code Install Smoke
+
+| Field | Value |
+| --- | --- |
+| VSIX | `artifacts/issue59-vsix/better-todo-tree-1.2.3-linux-x64.vsix` |
+| VS Code | `1.123.0` |
+| Installed extension | `fanaticpythoner.better-todo-tree@1.2.3` |
+| Archive integrity | `unzip -t`: OK |
+
+## Title Menu Entries
+
+| Command | Context | Icon |
+| --- | --- | --- |
+| `better-todo-tree.expand` | `better-todo-tree-expanded == false` | `$(expand-all)` |
+| `better-todo-tree.collapse` | `better-todo-tree-expanded == true` | `$(collapse-all)` |
+| `better-todo-tree.treeStateBusy` | `better-todo-tree-expansion-busy == true` | `refresh-spin-light.svg`, `refresh-spin-dark.svg` |
+
+## Commands
+
+```bash
+code --user-data-dir "$PWD/artifacts/issue59-vscode-user-data" --extensions-dir "$PWD/artifacts/issue59-vscode-extensions" --install-extension "$PWD/artifacts/issue59-vsix/better-todo-tree-1.2.3-linux-x64.vsix" --force
+code --user-data-dir "$PWD/artifacts/issue59-vscode-user-data" --extensions-dir "$PWD/artifacts/issue59-vscode-extensions" --list-extensions --show-versions
+```
+
+## Output
+
+```text
+Extension 'better-todo-tree-1.2.3-linux-x64.vsix' was successfully installed.
+fanaticpythoner.better-todo-tree@1.2.3
+```

--- a/package.json
+++ b/package.json
@@ -175,8 +175,13 @@
                     "group": "navigation@8"
                 },
                 {
-                    "command": "better-todo-tree.toggleTreeExpansion",
-                    "when": "view =~ /todo-tree/ && better-todo-tree-show-expand-button == true && better-todo-tree-collapsible == true && better-todo-tree-expansion-busy == false",
+                    "command": "better-todo-tree.expand",
+                    "when": "view =~ /todo-tree/ && better-todo-tree-show-expand-button == true && better-todo-tree-collapsible == true && better-todo-tree-expanded == false && better-todo-tree-expansion-busy == false",
+                    "group": "navigation@9"
+                },
+                {
+                    "command": "better-todo-tree.collapse",
+                    "when": "view =~ /todo-tree/ && better-todo-tree-show-expand-button == true && better-todo-tree-collapsible == true && better-todo-tree-expanded == true && better-todo-tree-expansion-busy == false",
                     "group": "navigation@9"
                 },
                 {

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -4389,6 +4389,62 @@ QUnit.test( "toggleTreeExpansion drives live expand and collapse operations on t
     } );
 } );
 
+QUnit.test( "issue #59 expansion commands publish expanded context for title icons", function( assert )
+{
+    var workspaceStateValues = {
+        expanded: false
+    };
+    var workspaceState = {
+        get: function( key, defaultValue )
+        {
+            return Object.prototype.hasOwnProperty.call( workspaceStateValues, key ) ? workspaceStateValues[ key ] : defaultValue;
+        },
+        update: function( key, value )
+        {
+            workspaceStateValues[ key ] = value;
+            return Promise.resolve();
+        }
+    };
+    var harness = createExtensionHarness( {
+        scanMode: 'open files',
+        workspaceState: workspaceState,
+        resourceConfig: { isDefaultRegex: true, enableMultiLine: false, regexCaseSensitive: true },
+        fileContents: {}
+    } );
+
+    function expandedContextWrites()
+    {
+        return harness.vscode.executedCommands.filter( function( call )
+        {
+            return call[ 0 ] === 'setContext' && call[ 1 ] === 'better-todo-tree-expanded';
+        } ).map( function( call )
+        {
+            return call[ 2 ];
+        } );
+    }
+
+    harness.extension.activate( harness.context );
+
+    return matrixHelpers.flushAsyncWork().then( function()
+    {
+        assert.deepEqual( expandedContextWrites(), [ false ] );
+        return harness.vscode.commandHandlers[ 'better-todo-tree.expand' ]();
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        assert.deepEqual( expandedContextWrites(), [ false, true ] );
+        return harness.vscode.commandHandlers[ 'better-todo-tree.collapse' ]();
+    } ).then( function()
+    {
+        return matrixHelpers.flushAsyncWork();
+    } ).then( function()
+    {
+        assert.deepEqual( expandedContextWrites(), [ false, true, false ] );
+    } );
+} );
+
 QUnit.test( "view changes and expansion mutations stay serialized across the actual tree view", function( assert )
 {
     var workspaceStateValues = {

--- a/test/package.manifest.test.js
+++ b/test/package.manifest.test.js
@@ -218,6 +218,35 @@ QUnit.test( 'view title busy placeholders are scoped to the active control inste
     assert.ok( groupBySubTagEntry.when.indexOf( 'better-todo-tree-grouping-busy == false' ) >= 0 );
 } );
 
+QUnit.test( 'issue #59 view title expansion control swaps icon commands by expanded context', function( assert )
+{
+    var packageJson = readPackageJson();
+    var titleMenu = packageJson.contributes.menus[ 'view/title' ];
+    var expansionEntries = titleMenu.filter( function( entry )
+    {
+        return entry.group === 'navigation@9' &&
+            (
+                entry.command === 'better-todo-tree.expand' ||
+                entry.command === 'better-todo-tree.collapse' ||
+                entry.command === 'better-todo-tree.toggleTreeExpansion'
+            );
+    } );
+    var commands = packageJson.contributes.commands.reduce( function( byName, entry )
+    {
+        byName[ entry.command ] = entry;
+        return byName;
+    }, {} );
+
+    assert.deepEqual( expansionEntries.map( function( entry ) { return entry.command; } ), [
+        'better-todo-tree.expand',
+        'better-todo-tree.collapse'
+    ] );
+    assert.equal( expansionEntries[ 0 ].when, "view =~ /todo-tree/ && better-todo-tree-show-expand-button == true && better-todo-tree-collapsible == true && better-todo-tree-expanded == false && better-todo-tree-expansion-busy == false" );
+    assert.equal( expansionEntries[ 1 ].when, "view =~ /todo-tree/ && better-todo-tree-show-expand-button == true && better-todo-tree-collapsible == true && better-todo-tree-expanded == true && better-todo-tree-expansion-busy == false" );
+    assert.equal( commands[ 'better-todo-tree.expand' ].icon, '$(expand-all)' );
+    assert.equal( commands[ 'better-todo-tree.collapse' ].icon, '$(collapse-all)' );
+} );
+
 QUnit.test( 'busy and composite tree commands have localization entries in both english and zh-cn bundles', function( assert )
 {
     var english = readPackageNls( 'package.nls.json' );


### PR DESCRIPTION
Render separate expand and collapse title commands so the sidebar control
matches the current tree expansion state.

Manifest:
- replace the toggle title menu item with explicit expand and collapse entries
- gate each title command on expanded and expansion-busy context keys
- preserve the navigation ordering for the expansion control slot

Coverage:
- assert manifest command ordering, when clauses, and contributed codicons
- assert expand and collapse command handlers publish expanded context changes
- add issue 59 install-smoke evidence and expansion-flow benchmark artifacts
