### PR TITLE
fix: probe RegExp indices and clean selected VSIX output

### DIFF
--- a/artifacts/perf/issue119-regexp-indices.md
+++ b/artifacts/perf/issue119-regexp-indices.md
@@ -1,0 +1,66 @@
+# Runtime Benchmarks
+
+- Baseline ref: `a6f60e0ce830c4649ac34fc05e5a1799ec91d151`
+- Current source: working tree
+- Node: `v25.2.0`
+- Selection mode: `scenario-list`
+- Declared suite: `mixed`
+- Result-count validation: `2 rows, suite-consistent=true, all-user-flow=false`
+
+## Machine Profile
+
+| Category | Field | Value |
+| --- | --- | --- |
+| Host | Hostname | n00ne-AERO-17-YD |
+| Host | OS | Ubuntu 22.04.5 LTS |
+| Host | Kernel | 6.8.0-124-generic |
+| Host | Architecture | x64 |
+| Host | Load Average | 3.68, 3.86, 4.01 |
+| Host | Available Parallelism | - |
+| CPU | Model | Intel(R) Core(TM) i9-14900HX |
+| CPU | Vendor | GenuineIntel |
+| CPU | Topology | 16 logical CPU(s), 2 thread(s)/core, 8 core(s)/socket, 1 socket(s), 1 NUMA node(s) |
+| CPU | Frequency | 800 MHz to 5,800 MHz |
+| CPU | Cache | L1d 384 KiB (8 instances), L1i 256 KiB (8 instances), L2 16 MiB (8 instances), L3 36 MiB (1 instance) |
+| Memory | Total RAM | 62.51 GiB (`67,119,751,168 bytes`) |
+| Memory | Available At Collection | 13.51 GiB (`14,510,288,896 bytes`) |
+| Memory | Online Physical RAM | 66.00 GiB (`70,866,960,384 bytes`) |
+| Memory | Swap | total 120 GiB (`128,848,973,824 bytes`); free 108 GiB (`115,825,471,488 bytes`) |
+| Memory | DMI / SPD | Unavailable: /sys/firmware/dmi/tables/smbios_entry_point: Permission denied /dev/mem: Permission denied |
+| Storage | Root Device | nvme0n1 (Samsung SSD 9100 PRO 4TB), 3.64 TiB (`4,000,787,030,016 bytes`), transport nvme, rotational=false, readOnly=false |
+
+## Scenario Model
+
+| Scenario | Kind | User flow | Measurement scope | Input model |
+| --- | --- | --- | --- | --- |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | Trigger a workspace refresh with custom regex scanning and rebuild the visible tree from workspace matches. | Workspace refresh orchestration, ripgrep event handling, regex-match normalization, result application, and tree rebuild/render. | Fixture ripgrep matches, fixture file contents, and fixture normalized regex results in a VS Code event harness. |
+| scan-large-custom-regex | microbenchmark | - | - | - |
+
+## Metric Model
+
+| Table | Value model | Accuracy model |
+| --- | --- | --- |
+| Latency | Wall-clock elapsed time around each harness flow iteration, summarized as min/p50/p90/p95/max. | Exact for each sampled iteration in this run. |
+| Profiled RSS Burst | Difference between the isolated scenario worker RSS measured immediately before the flow and that worker iteration's OS high-water-mark peak RSS. | Exact for the measured worker iteration, using `process.memoryUsage().rss` at flow start and `process.resourceUsage().maxRSS` for the peak. |
+| Profiled Peak RSS | Highest process RSS reached by each isolated scenario worker iteration. | Exact worker-process high-water mark from `process.resourceUsage().maxRSS`. |
+
+## Latency
+
+| Scenario | Kind | Baseline p50 ms | Current p50 ms | Baseline p90 ms | Current p90 ms | Baseline p95 ms | Current p95 ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 52.46 | 2.4 | 55.76 | 2.56 | 57.02 | 3.38 |
+| scan-large-custom-regex | microbenchmark | 6.94 | 10.89 | 8.03 | 11.45 | 9.33 | 12.03 |
+
+## Profiled RSS Burst
+
+| Scenario | Kind | Baseline p50 MiB | Current p50 MiB | Baseline p90 MiB | Current p90 MiB | Baseline p95 MiB | Current p95 MiB | Baseline Max MiB | Current Max MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 77.22 | 13.75 | 83.75 | 14.2 | 87.63 | 14.22 | 87.63 | 14.22 |
+| scan-large-custom-regex | microbenchmark | 0.75 | 0.75 | 0.75 | 0.75 | 0.75 | 0.75 | 0.75 | 0.75 |
+
+## Profiled Peak RSS
+
+| Scenario | Kind | Baseline p50 RSS MiB | Current p50 RSS MiB | Baseline p90 RSS MiB | Current p90 RSS MiB | Baseline p95 RSS MiB | Current p95 RSS MiB | Baseline Max RSS MiB | Current Max RSS MiB |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| workspace-custom-relative-rebuild-visible-tree | user-flow | 133.39 | 70.15 | 139.96 | 70.39 | 144.14 | 70.4 | 144.14 | 70.4 |
+| scan-large-custom-regex | microbenchmark | 250.8 | 251.34 | 251.23 | 251.8 | 251.64 | 251.8 | 251.64 | 251.8 |

--- a/scripts/release/build-vsix.mjs
+++ b/scripts/release/build-vsix.mjs
@@ -77,6 +77,30 @@ function ensureOutputDirectory(directory) {
     fs.mkdirSync(directory, { recursive: true });
 }
 
+function isSelectedTargetPackage(fileName, packageName, selectedTargets) {
+    const extension = '.vsix';
+    const prefix = `${packageName}-`;
+
+    if (!fileName.startsWith(prefix) || !fileName.endsWith(extension)) {
+        return false;
+    }
+
+    const versionAndTarget = fileName.slice(prefix.length, -extension.length);
+
+    return selectedTargets.some((target) => {
+        const suffix = `-${target}`;
+        return versionAndTarget.endsWith(suffix) && versionAndTarget.length > suffix.length;
+    });
+}
+
+function cleanSelectedTargetOutputs(directory, packageName, selectedTargets) {
+    fs.readdirSync(directory)
+        .filter((fileName) => isSelectedTargetPackage(fileName, packageName, selectedTargets))
+        .forEach((fileName) => {
+            fs.unlinkSync(path.join(directory, fileName));
+        });
+}
+
 function ripgrepPlatformDirectory(platform) {
     return `${platform.os}-${platform.arch}`;
 }
@@ -157,6 +181,7 @@ async function main() {
     const selectedTargets = normalizeRequestedTargets(process.argv.slice(2), supportedTargets);
 
     ensureOutputDirectory(outputDirectory);
+    cleanSelectedTargetOutputs(outputDirectory, packageJson.name, selectedTargets);
 
     try {
         if (process.env.SKIP_PREPUBLISH !== '1') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,9 +50,28 @@ function supportsRegExpIndices()
         return regExpIndicesSupported;
     }
 
-    regExpIndicesSupported = Object.prototype.hasOwnProperty.call( RegExp.prototype, 'hasIndices' );
+    try
+    {
+        var regex = regexRegistry.createRegExp( 'empty', 'd' );
+        var match = regex.exec( '' );
+        regExpIndicesSupported = regex.hasIndices === true && match !== null && Array.isArray( match.indices );
+    }
+    catch( error )
+    {
+        if( !( error instanceof SyntaxError ) )
+        {
+            throw error;
+        }
+
+        regExpIndicesSupported = false;
+    }
 
     return regExpIndicesSupported;
+}
+
+function clearRegExpFeatureCache()
+{
+    regExpIndicesSupported = undefined;
 }
 
 function isHexColour( colour )
@@ -1079,6 +1098,7 @@ module.exports.getLanguageConfigurationSignature = getLanguageConfigurationSigna
 module.exports.getResourceConfig = getResourceConfig;
 module.exports.getTagRegexSource = getTagRegexSource;
 module.exports.supportsRegExpIndices = supportsRegExpIndices;
+module.exports.clearRegExpFeatureCache = clearRegExpFeatureCache;
 module.exports.DEFAULT_REGEX_SOURCE = DEFAULT_REGEX_SOURCE;
 module.exports.LEGACY_MARKDOWN_TASK_FRAGMENT = regexRegistry.LEGACY_MARKDOWN_TASK_FRAGMENT;
 module.exports.extractTag = extractTag;

--- a/test/detection.regex-matrix.test.js
+++ b/test/detection.regex-matrix.test.js
@@ -5,6 +5,7 @@ var regexRegistry = require( '../src/regexRegistry.js' );
 var languageMatrix = require( './languageMatrix.js' );
 var issue888Helpers = require( './issue888Helpers.js' );
 var matrixHelpers = require( './matrixHelpers.js' );
+var moduleHelpers = require( './moduleHelpers.js' );
 var stubs = require( './stubs.js' );
 
 function tagRegexWithTail( tail )
@@ -266,6 +267,49 @@ QUnit.module( "detection regex matrix", function()
         assert.equal( utils.formatLabel( '${tag} ${after}', normalized ), utils.formatLabel( '${tag} ${after}', scanned ) );
         assert.equal( normalized.before, '//' );
         assert.equal( normalized.after, 'workspace-visible text' );
+    } );
+
+    QUnit.test( "issue #119 workspace normalization skips indices when the host rejects the flag", function( assert )
+    {
+        var config = matrixHelpers.createConfig( {
+            tagList: [ 'TODO' ],
+            regexSource: regexRegistry.pattern( 'legacyMarkdownCompatibilityTodo' ),
+            subTagRegexString: regexRegistry.pattern( 'subTagPrefix' )
+        } );
+        var uri = matrixHelpers.createUri( '/tmp/issue-119.typ' );
+        var text = '// TODO typst-project item';
+        var normalized;
+
+        try
+        {
+            moduleHelpers.withRegExpWithoutIndices( function()
+            {
+                utils.clearRegExpFeatureCache();
+                utils.init( config );
+
+                normalized = detection.normalizeWorkspaceRegexMatch( uri, {
+                    fsPath: uri.fsPath,
+                    line: 1,
+                    column: 1,
+                    lines: text,
+                    match: '// TODO',
+                    absoluteOffset: 0,
+                    submatches: [ {
+                        match: '// TODO',
+                        start: 0,
+                        end: 7
+                    } ]
+                } );
+            } );
+        }
+        finally
+        {
+            utils.clearRegExpFeatureCache();
+        }
+
+        assert.equal( normalized.actualTag, 'TODO' );
+        assert.equal( normalized.displayText, 'typst-project item' );
+        assert.equal( normalized.column, 4 );
     } );
 
     QUnit.test( "issue #36 comment-prefix labels match reload labels", function( assert )

--- a/test/extension.scan-parity.test.js
+++ b/test/extension.scan-parity.test.js
@@ -6238,6 +6238,89 @@ QUnit.test( "workspace scan custom-regex path normalizes oversized ripgrep match
     } );
 } );
 
+QUnit.test( "issue #119 workspace scan applies raw regex results when indices are unavailable", function( assert )
+{
+    var filePath = '/workspace/issue-119.typ';
+    var text = '// TODO typst-project item\n';
+    var regexSource = actualRegexRegistry.pattern( 'legacyMarkdownCompatibilityTodo' );
+    var config = matrixHelpers.createConfig( {
+        tagList: [ 'TODO' ],
+        regexSource: regexSource,
+        shouldBeCaseSensitive: true,
+        subTagRegexString: actualRegexRegistry.pattern( 'subTagPrefix' )
+    } );
+
+    return helpers.withRegExpWithoutIndices( function()
+    {
+        actualUtils.clearRegExpFeatureCache();
+        actualUtils.init( config );
+
+        var harness = createExtensionHarness( {
+            scanMode: 'workspace',
+            regexSource: regexSource,
+            resourceConfig: { isDefaultRegex: false, enableMultiLine: false, regexCaseSensitive: true },
+            workspaceFolders: [ { uri: matrixHelpers.createUri( '/workspace' ), name: 'workspace' } ],
+            normalizeWorkspaceResult: function( match, uri, snapshot )
+            {
+                return actualDetection.normalizeWorkspaceRegexMatch( uri, match, snapshot );
+            },
+            ripgrepMatches: [ {
+                fsPath: filePath,
+                line: 1,
+                column: 1,
+                match: '// TODO',
+                lines: text,
+                absoluteOffset: 0,
+                submatches: [ {
+                    match: '// TODO',
+                    start: 0,
+                    end: 7
+                } ]
+            } ],
+            fileContents: {
+                '/workspace/issue-119.typ': text
+            },
+            fileStats: {
+                '/workspace/issue-119.typ': { size: 9999999 }
+            },
+            streamScannerOverrides: {
+                maxInMemoryBytes: 16,
+                chunkBytes: 12,
+                overlapBytes: 4
+            }
+        } );
+
+        harness.extension.activate( harness.context );
+
+        return matrixHelpers.flushAsyncWork().then( function()
+        {
+            assert.equal( harness.errorMessages.length, 0 );
+            assert.equal( harness.warningMessages.length, 0 );
+            assert.equal( harness.normalizeWorkspaceCalls.length, 1 );
+            assert.equal( harness.readFileCalls.indexOf( filePath ), -1 );
+
+            var replaceCalls = harness.provider.replaceCalls.filter( function( call )
+            {
+                return call.uri.fsPath === filePath;
+            } );
+
+            assert.equal( replaceCalls.length, 1 );
+
+            var result = replaceCalls[ 0 ].results[ 0 ];
+            assert.equal( result.actualTag, 'TODO' );
+            assert.equal( result.displayText, 'typst-project item' );
+            assert.equal( result.column, 4 );
+        } );
+    } ).then( function()
+    {
+        actualUtils.clearRegExpFeatureCache();
+    }, function( error )
+    {
+        actualUtils.clearRegExpFeatureCache();
+        throw error;
+    } );
+} );
+
 QUnit.test( "workspace scan reports oversized stat errors as workspace scan issues without crashing", function( assert )
 {
     var harness = createExtensionHarness( {

--- a/test/moduleHelpers.js
+++ b/test/moduleHelpers.js
@@ -25,4 +25,55 @@ function loadWithStubs( modulePath, stubs )
     }
 }
 
+function withRegExpWithoutIndices( callback )
+{
+    var nativeRegExp = global.RegExp;
+
+    function restoreRegExp()
+    {
+        global.RegExp = nativeRegExp;
+    }
+
+    function RegExpWithoutIndices( source, flags )
+    {
+        if( typeof flags === 'string' && flags.indexOf( 'd' ) !== -1 )
+        {
+            throw new SyntaxError( 'Invalid flags: ' + flags.split( '' ).sort().join( '' ) );
+        }
+
+        return new nativeRegExp( source, flags );
+    }
+
+    RegExpWithoutIndices.prototype = nativeRegExp.prototype;
+    Object.setPrototypeOf( RegExpWithoutIndices, nativeRegExp );
+
+    try
+    {
+        global.RegExp = RegExpWithoutIndices;
+        var result = callback();
+
+        if( result && typeof ( result.then ) === 'function' )
+        {
+            return result.then( function( value )
+            {
+                restoreRegExp();
+                return value;
+            }, function( error )
+            {
+                restoreRegExp();
+                throw error;
+            } );
+        }
+
+        restoreRegExp();
+        return result;
+    }
+    catch( error )
+    {
+        restoreRegExp();
+        throw error;
+    }
+}
+
 module.exports.loadWithStubs = loadWithStubs;
+module.exports.withRegExpWithoutIndices = withRegExpWithoutIndices;

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,6 +6,7 @@ var utils = require( '../src/utils.js' );
 var attributes = require( '../src/attributes.js' );
 var regexRegistry = require( '../src/regexRegistry.js' );
 var stubs = require( './stubs.js' );
+var moduleHelpers = require( './moduleHelpers.js' );
 var searchResults = require( '../src/searchResults.js' );
 
 QUnit.test( "utils.isHexColour", function( assert )
@@ -388,6 +389,34 @@ QUnit.test( "utils.getRegexForEditorSearch requests indices only when the host s
     var regex = utils.getRegexForEditorSearch( true, uri, { includeIndices: true } );
 
     assert.equal( regex.flags.indexOf( 'd' ) !== -1, utils.supportsRegExpIndices() );
+} );
+
+QUnit.test( "utils.getRegexForEditorSearch skips indices when the constructor rejects the flag", function( assert )
+{
+    var testConfig = stubs.getTestConfig();
+    var uri = { toString: function() { return "/tmp/no-indices.js"; } };
+    var regex;
+
+    try
+    {
+        moduleHelpers.withRegExpWithoutIndices( function()
+        {
+            utils.clearRegExpFeatureCache();
+            utils.init( testConfig );
+
+            assert.equal( utils.supportsRegExpIndices(), false );
+            assert.equal( Object.prototype.hasOwnProperty.call( RegExp.prototype, 'hasIndices' ), true );
+            assert.equal( function()
+            {
+                regex = utils.getRegexForEditorSearch( true, uri, { includeIndices: true } );
+                return regex.flags;
+            }(), 'gim' );
+        } );
+    }
+    finally
+    {
+        utils.clearRegExpFeatureCache();
+    }
 } );
 
 QUnit.test( "utils.isIncluded returns true when no includes or excludes are specified", function( assert )

--- a/test/workflows.github.test.js
+++ b/test/workflows.github.test.js
@@ -375,6 +375,16 @@ QUnit.test( 'VSIX builder stages one ripgrep-universal binary for each native ta
     assert.ok( buildScript.indexOf( 'finally {\n        resetRipgrepStage();\n    }' ) !== -1 );
 } );
 
+QUnit.test( 'VSIX builder removes stale selected target outputs before packing', function( assert )
+{
+    var buildScript = fs.readFileSync( path.join( __dirname, '..', 'scripts', 'release', 'build-vsix.mjs' ), 'utf8' );
+
+    assert.ok( buildScript.indexOf( 'function isSelectedTargetPackage' ) !== -1 );
+    assert.ok( buildScript.indexOf( 'function cleanSelectedTargetOutputs' ) !== -1 );
+    assert.ok( buildScript.indexOf( 'fs.unlinkSync(path.join(directory, fileName))' ) !== -1 );
+    assert.ok( buildScript.indexOf( 'cleanSelectedTargetOutputs(outputDirectory, packageJson.name, selectedTargets)' ) !== -1 );
+} );
+
 QUnit.test( 'security workflow keeps dependency review and CodeQL coverage pinned', function( assert )
 {
     assertSecurityWorkflowContract( assert, readWorkflow( 'security.yml' ) );


### PR DESCRIPTION
Require a successful `d`-flag RegExp compile and match before indexed
regex scanning is enabled. Remove stale native-target VSIX artifacts before
targeted release packaging starts.

Runtime:
- detect RegExp indices support by constructing a `d`-flag regex through the registry
- treat unsupported `d` syntax as disabled indices support while rethrowing other errors
- expose cache reset API for deterministic feature-probe tests

Release packaging:
- delete stale package-name-matched VSIX files for selected native targets before packaging
- preserve unrelated VSIX files through package-name and target-suffix checks

Coverage and evidence:
- add editor-search, workspace-normalization, and workspace-scan cases for hosts rejecting `dgm`
- add shared RegExp constructor shim for no-indices host simulation
- assert selected-target VSIX cleanup in workflow tests
- add issue119 RegExp-indices latency and RSS evidence

Fixes https://github.com/FanaticPythoner/better-todo-tree/issues/119
