### PR TITLE
feat: add minimal devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/curl-apt-get:1": {
+      "version": "1.0.18",
+      "resolved": "ghcr.io/devcontainers-extra/features/curl-apt-get@sha256:7fb32e4ebdd440369a598e7a27b1ed56c9e73eb6b4f595d30969862d2fc68e40",
+      "integrity": "sha256:7fb32e4ebdd440369a598e7a27b1ed56c9e73eb6b4f595d30969862d2fc68e40"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "better-todo-tree-dev",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:24-trixie",
+    "features": {
+        "ghcr.io/devcontainers-extra/features/curl-apt-get:1": {}
+    },
+    "postCreateCommand": "curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin && npm install",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "ms-vscode.extension-test-runner"
+            ]
+        }
+    }
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -25,3 +25,4 @@ buildCodiconNames.js
 old-*.js
 *.bak
 *~
+.devcontainer/


### PR DESCRIPTION
As I mentioned in #119 a devcontainer setup makes it easier for other to contribute to this project or test unreleased fixes & features.

I added a minimal setup wich includes the following:
- based on debian trixie
- node v24
- curl (via official devcontainer features, needed to then install 'just')
- just
- 2 extensions: eslint & extension testrunner

Let me now if you have any questions or would like to add anything else. Or if your familiar with devcontainers just add anything you need yourself.

Cheers and thanks for bringing the todo-tree back to life!