### PR TITLE
feat: automate verified cross-platform VSIX previews for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,20 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test-build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -50,10 +52,3 @@ jobs:
         run: |
           rm -rf artifacts/vsix
           SKIP_PREPUBLISH=1 node scripts/release/build-vsix.mjs linux-x64
-
-      - name: Upload smoke-test VSIX
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: better-todo-tree-linux-x64-vsix
-          path: artifacts/vsix/*-linux-x64.vsix
-          if-no-files-found: error

--- a/.github/workflows/pr-vsix-base-event.yml
+++ b/.github/workflows/pr-vsix-base-event.yml
@@ -1,0 +1,20 @@
+name: PR VSIX Base Event
+
+on:
+  push:
+    branches:
+      - "**"
+
+permissions: {}
+
+concurrency:
+  group: pr-vsix-base-event-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  signal:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: Signal trusted base refresh
+        run: ":"

--- a/.github/workflows/pr-vsix-build.yml
+++ b/.github/workflows/pr-vsix-build.yml
@@ -1,0 +1,84 @@
+name: PR VSIX Build
+run-name: >-
+  ${{ format('PR VSIX Build PR #{0} head {1} base {2} merge {3} action {4}', github.event.client_payload.pull_request_number, github.event.client_payload.head_sha, github.event.client_payload.base_sha, github.event.client_payload.merge_sha, github.event.client_payload.cause) }}
+
+on:
+  repository_dispatch:
+    types:
+      - refresh-pr-vsix
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    concurrency:
+      group: pr-vsix-build-${{ github.event.client_payload.pull_request_number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check out trusted workflow helpers
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve immutable build context
+        id: context
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_VSIX_API_RETRY_ATTEMPTS: 4
+          PR_VSIX_API_RETRY_BASE_MS: 1000
+          PR_VSIX_API_RETRY_MAX_MS: 60000
+          PR_VSIX_MERGE_ATTEMPTS: 12
+          PR_VSIX_MERGE_INTERVAL_MS: 5000
+        run: node scripts/ci/resolve-pr-vsix-context.mjs
+
+      - name: Check out immutable build context
+        if: steps.context.outputs.build == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ steps.context.outputs.checkout-sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install dependencies
+        if: steps.context.outputs.build == 'true'
+        run: npm ci
+
+      - name: Run test suite
+        if: steps.context.outputs.build == 'true'
+        run: npm test
+
+      - name: Build production bundle
+        if: steps.context.outputs.build == 'true'
+        run: npm run vscode:prepublish
+
+      - name: Build PR VSIX bundle
+        if: steps.context.outputs.build == 'true'
+        env:
+          PR_VSIX_FILENAME: better-todo-tree-pr-${{ steps.context.outputs.pull-request-number }}.vsix
+        run: |
+          rm -rf artifacts/vsix
+          SKIP_PREPUBLISH=1 node scripts/release/build-vsix.mjs pr-preview
+          node scripts/ci/verify-pr-vsix.mjs "artifacts/vsix/$PR_VSIX_FILENAME"
+
+      - name: Upload PR VSIX bundle
+        if: steps.context.outputs.build == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: better-todo-tree-pr-${{ steps.context.outputs.pull-request-number }}.vsix
+          path: artifacts/vsix/better-todo-tree-pr-${{ steps.context.outputs.pull-request-number }}.vsix
+          if-no-files-found: error
+          retention-days: 90
+          archive: false
+          overwrite: true

--- a/.github/workflows/pr-vsix-comment.yml
+++ b/.github/workflows/pr-vsix-comment.yml
@@ -1,0 +1,78 @@
+name: PR VSIX Comment
+
+on:
+  workflow_run:
+    workflows:
+      - PR VSIX Build
+      - PR VSIX Event
+    types:
+      - in_progress
+      - completed
+
+permissions: {}
+
+jobs:
+  resolve:
+    if: >-
+      (github.event.workflow_run.name == 'PR VSIX Build' && github.event.workflow_run.event == 'repository_dispatch') ||
+      (github.event.action == 'completed' && github.event.workflow_run.name == 'PR VSIX Event' && (github.event.workflow_run.event == 'pull_request_target' || github.event.workflow_run.event == 'pull_request') && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      pull-request-number: ${{ steps.identity.outputs.pull-request-number }}
+      processable: ${{ steps.identity.outputs.processable }}
+
+    steps:
+      - name: Check out trusted resolver
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve pull request identity
+        id: identity
+        run: node scripts/ci/sync-pr-vsix-comment.mjs resolve >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: resolve
+    if: needs.resolve.outputs.processable == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: pr-vsix-comment-${{ needs.resolve.outputs.pull-request-number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out trusted publisher
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+
+      - name: Synchronize PR VSIX comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_VSIX_API_RETRY_ATTEMPTS: 4
+          PR_VSIX_API_RETRY_BASE_MS: 1000
+          PR_VSIX_API_RETRY_MAX_MS: 60000
+          PR_VSIX_MERGE_ATTEMPTS: 12
+          PR_VSIX_MERGE_INTERVAL_MS: 5000
+        run: node scripts/ci/sync-pr-vsix-comment.mjs

--- a/.github/workflows/pr-vsix-event.yml
+++ b/.github/workflows/pr-vsix-event.yml
@@ -1,0 +1,52 @@
+name: PR VSIX Event
+run-name: PR VSIX Event #${{ github.event.pull_request.number }} ${{ github.event.action }}
+
+on:
+  pull_request:
+    types:
+      - closed
+      - edited
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
+  pull_request_target:
+    types:
+      - closed
+      - edited
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
+
+permissions: {}
+
+jobs:
+  record:
+    if: >-
+      (github.event.action != 'edited' || github.event.changes.base != null) &&
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'safe-to-test')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: >-
+        ${{ github.event_name == 'pull_request' && github.event.action != 'closed' &&
+        format('pr-vsix-fallback-{0}', github.event.pull_request.number) ||
+        format('pr-vsix-build-{0}', github.event.pull_request.number) }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Create lifecycle marker
+        run: touch pr-vsix-event
+
+      - name: Upload lifecycle marker
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-${{ github.event.pull_request.merge_commit_sha || 'none' }}-${{ github.event.action }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: pr-vsix-event
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/pr-vsix-refresh.yml
+++ b/.github/workflows/pr-vsix-refresh.yml
@@ -1,0 +1,64 @@
+name: PR VSIX Refresh
+
+on:
+  repository_dispatch:
+    types:
+      - continue-pr-vsix-refresh
+  workflow_run:
+    workflows:
+      - PR VSIX Base Event
+    types:
+      - completed
+  schedule:
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: >-
+    ${{ github.event_name == 'workflow_run' && format('branch-{0}', github.event.workflow_run.head_branch) ||
+    github.event_name == 'repository_dispatch' && format('continuation-{0}', github.event.client_payload.base || 'all') ||
+    'all' }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out trusted refresher
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+
+      - name: Refresh stale PR VSIX bundles
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_VSIX_API_RETRY_ATTEMPTS: 4
+          PR_VSIX_API_RETRY_BASE_MS: 1000
+          PR_VSIX_API_RETRY_MAX_MS: 60000
+          PR_VSIX_ARTIFACT_RETENTION_DAYS: 90
+          PR_VSIX_DISPATCH_INTERVAL_MS: 1000
+          PR_VSIX_MERGE_ATTEMPTS: 12
+          PR_VSIX_MERGE_INTERVAL_MS: 5000
+          PR_VSIX_PENDING_HOURS: 6
+          PR_VSIX_REFRESH_BATCH_SIZE: 400
+          PR_VSIX_REFRESH_CONCURRENCY: 8
+          PR_VSIX_RENEWAL_DAYS: 14
+        run: node scripts/ci/refresh-pr-vsix.mjs

--- a/justfile
+++ b/justfile
@@ -200,12 +200,28 @@ test-actions-release-build:
   )
 
 # Examples:
+#   just test-actions-pr-vsix-build
+test-actions-pr-vsix-build:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  {{node_bootstrap}}
+  npm run vscode:prepublish
+  preview_dir="artifacts/vsix/pr-preview-test"
+  preview_name="better-todo-tree-pr-1.vsix"
+  rm -rf "$preview_dir"
+  VSIX_OUTDIR="$preview_dir" \
+    PR_VSIX_FILENAME="$preview_name" \
+    SKIP_PREPUBLISH=1 \
+    node scripts/release/build-vsix.mjs pr-preview
+  node scripts/ci/verify-pr-vsix.mjs "$preview_dir/$preview_name"
+
+# Examples:
 #   just test-actions-latest-build
 test-actions-latest-build:
   #!/usr/bin/env bash
   set -euo pipefail
   {{node_bootstrap}}
-  npx qunit test/workflows.github.test.js test/release.workflow-scripts.test.js
+  npx qunit test/workflows.github.test.js test/release.workflow-scripts.test.js test/pr-vsix-comment.test.js test/pr-vsix-preview.test.js test/pr-vsix-refresh.test.js
 
 # Examples:
 #   just test-actions
@@ -215,6 +231,7 @@ test-actions:
   just test
   just lint-actions
   just test-actions-ci
+  just test-actions-pr-vsix-build
   just test-actions-release-build
   just test-actions-latest-build
 

--- a/scripts/ci/refresh-pr-vsix.mjs
+++ b/scripts/ci/refresh-pr-vsix.mjs
@@ -1,0 +1,472 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    BOT_LOGIN,
+    COMMENT_MARKER,
+    PrVsixInvariantError,
+    apiRetryFromEnvironment,
+    automaticBuildAllowed,
+    createGitHubApi,
+    parseCommentMetadata,
+    previewArtifactName,
+    pullRequestContext,
+    waitForStablePullRequest
+} from './sync-pr-vsix-comment.mjs';
+
+const modulePath = fileURLToPath(import.meta.url);
+
+function requirePositiveNumber(value, label) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new PrVsixInvariantError(`${label}: expected a positive number`);
+    }
+    return parsed;
+}
+
+function managedMetadata(comments) {
+    return comments.filter((comment) => comment && comment.user && comment.user.login === BOT_LOGIN &&
+        typeof comment.body === 'string' && comment.body.includes(COMMENT_MARKER))
+        .map((comment) => parseCommentMetadata(comment.body))
+        .filter(Boolean);
+}
+
+function metadataMatchesContext(metadata, context) {
+    return metadata.headSha === context.headSha && metadata.baseSha === context.baseSha &&
+        metadata.mergeSha === context.mergeSha;
+}
+
+function scheduledRefreshCause({ pullRequest, context, comments, artifacts, now, renewalWindowMs, pendingWindowMs }) {
+    const metadata = managedMetadata(comments).find((candidate) =>
+        metadataMatchesContext(candidate, context)
+    );
+    if (!metadata) {
+        return 'repair';
+    }
+    if (['pending', 'provisional', 'transitioning'].includes(metadata.phase)) {
+        const observedAt = Date.parse(metadata.startedAt);
+        return !Number.isFinite(observedAt) || now - observedAt >= pendingWindowMs ? 'repair' : undefined;
+    }
+    if (metadata.phase !== 'completed') {
+        return 'repair';
+    }
+    if (!metadata.artifactId) {
+        return artifacts.length > 0 || metadata.conclusion === 'success' ? 'repair' : undefined;
+    }
+    if (artifacts.length !== 1) {
+        return 'repair';
+    }
+
+    const expectedName = previewArtifactName(pullRequest.number);
+    const artifact = artifacts.find((candidate) =>
+        candidate.id === metadata.artifactId && candidate.name === expectedName &&
+        candidate.workflow_run && candidate.workflow_run.id === metadata.runId
+    );
+    if (!artifact || artifact.expired) {
+        return 'repair';
+    }
+    const expiresAt = Date.parse(artifact.expires_at);
+    if (!Number.isFinite(expiresAt)) {
+        return 'repair';
+    }
+    return expiresAt - now <= renewalWindowMs ? 'renewal' : undefined;
+}
+
+function requiresScheduledRefresh(options) {
+    return scheduledRefreshCause({ ...options, context: pullRequestContext(options.pullRequest) }) !== undefined;
+}
+
+function refreshPayload(context, cause) {
+    if (!context || !Number.isSafeInteger(context.pullRequestNumber)) {
+        return undefined;
+    }
+    return Object.freeze({
+        pull_request_number: context.pullRequestNumber,
+        head_sha: context.headSha,
+        base_sha: context.baseSha,
+        merge_sha: context.mergeSha,
+        cause
+    });
+}
+
+async function mapConcurrent(values, concurrency, operation) {
+    const results = new Array(values.length);
+    const failures = [];
+    let cursor = 0;
+    async function worker() {
+        while (cursor < values.length) {
+            const index = cursor;
+            cursor += 1;
+            try {
+                results[index] = await operation(values[index]);
+            } catch (cause) {
+                failures.push(new PrVsixInvariantError(`refresh item ${index}: ${cause.message || String(cause)}`, {
+                    cause
+                }));
+            }
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker));
+    if (failures.length > 0) {
+        throw new AggregateError(failures, `${failures.length} PR VSIX refresh operations failed`);
+    }
+    return results;
+}
+
+function createDispatchScheduler(api, { intervalMs, now = Date.now, sleep = (delay) =>
+    new Promise((resolve) => setTimeout(resolve, delay)) }) {
+    if (!Number.isSafeInteger(intervalMs) || intervalMs < 0) {
+        throw new PrVsixInvariantError('dispatch interval: expected a non-negative integer');
+    }
+    let queue = Promise.resolve();
+    let nextDispatchAt = 0;
+    return function dispatchRepositoryEvent(eventType, payload) {
+        let release;
+        const predecessor = queue;
+        queue = new Promise((resolve) => {
+            release = resolve;
+        });
+        return predecessor.then(async () => {
+            let retryAfterMs = 0;
+            try {
+                const delay = Math.max(0, nextDispatchAt - now());
+                if (delay > 0) {
+                    await sleep(delay);
+                }
+                return await api.dispatchRepositoryEvent(eventType, payload);
+            } catch (error) {
+                retryAfterMs = Number.isFinite(error && error.retryAfterMs) ? error.retryAfterMs : 0;
+                throw error;
+            } finally {
+                nextDispatchAt = now() + Math.max(intervalMs, retryAfterMs);
+                release();
+            }
+        });
+    };
+}
+
+function managedCommentPullRequestNumber(comment) {
+    if (!comment || !comment.user || comment.user.login !== BOT_LOGIN ||
+        typeof comment.body !== 'string' || !comment.body.includes(COMMENT_MARKER)) {
+        return undefined;
+    }
+    let url;
+    try {
+        url = new URL(comment.issue_url);
+    } catch (cause) {
+        throw new PrVsixInvariantError('managed comment issue URL: expected an absolute URL', { cause });
+    }
+    const value = Number(url.pathname.split('/').filter(Boolean).pop());
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new PrVsixInvariantError('managed comment issue URL: expected a positive issue number');
+    }
+    return value;
+}
+
+function managedArtifactPullRequestNumber(artifact) {
+    const name = artifact && String(artifact.name || '');
+    const suffix = '.vsix';
+    if (!name.startsWith('better-todo-tree-pr-') || !name.endsWith(suffix)) {
+        return undefined;
+    }
+    const value = Number(name.slice('better-todo-tree-pr-'.length, -suffix.length));
+    return Number.isSafeInteger(value) && value > 0 && previewArtifactName(value) === name ? value : undefined;
+}
+
+function groupScheduledState(pullRequests, comments, artifacts) {
+    const pullRequestNumbers = new Set(pullRequests.map((pullRequest) => pullRequest.number));
+    const commentsByPullRequest = new Map();
+    const artifactsByName = new Map();
+    const managedPullRequestNumbers = new Set();
+    comments.forEach((comment) => {
+        const pullRequestNumber = managedCommentPullRequestNumber(comment);
+        if (pullRequestNumber === undefined) {
+            return;
+        }
+        managedPullRequestNumbers.add(pullRequestNumber);
+        const bucket = commentsByPullRequest.get(pullRequestNumber) || [];
+        bucket.push(comment);
+        commentsByPullRequest.set(pullRequestNumber, bucket);
+    });
+    artifacts.forEach((artifact) => {
+        const pullRequestNumber = managedArtifactPullRequestNumber(artifact);
+        if (pullRequestNumber === undefined || !managedPullRequestNumbers.has(pullRequestNumber)) {
+            return;
+        }
+        const bucket = artifactsByName.get(artifact.name) || [];
+        bucket.push(artifact);
+        artifactsByName.set(artifact.name, bucket);
+    });
+    const closedCandidates = Array.from(managedPullRequestNumbers)
+        .filter((pullRequestNumber) => !pullRequestNumbers.has(pullRequestNumber))
+        .sort((left, right) => left - right);
+    return Object.freeze({ commentsByPullRequest, artifactsByName, closedCandidates });
+}
+
+function requiresAuthorizationRevocation({ pullRequest, comments, artifacts }) {
+    const context = pullRequestContext(pullRequest);
+    const metadata = managedMetadata(comments);
+    const currentBlocked = metadata.length === 1 && metadataMatchesContext(metadata[0], context) &&
+        metadata[0].phase === 'blocked';
+    return !currentBlocked || artifacts.length > 0;
+}
+
+function requiresClosedRepair(comments, artifacts) {
+    const metadata = managedMetadata(comments);
+    return artifacts.length > 0 || metadata.length !== 1 || metadata[0].phase !== 'closed';
+}
+
+async function refreshOpenPullRequests({
+    api,
+    base,
+    scheduled,
+    now,
+    renewalWindowMs,
+    pendingWindowMs,
+    concurrency,
+    mergeRetry,
+    commentSince,
+    dispatchRepositoryEvent = api.dispatchRepositoryEvent.bind(api),
+    phase = 'open',
+    cursor = 0,
+    batchSize = Number.MAX_SAFE_INTEGER
+}) {
+    if (!['open', 'closed'].includes(phase) || !Number.isSafeInteger(cursor) || cursor < 0 ||
+        !Number.isSafeInteger(batchSize) || batchSize <= 0 || phase === 'closed' && !scheduled) {
+        throw new PrVsixInvariantError('refresh cursor: expected a valid phase, cursor, and batch size');
+    }
+    const pullRequests = (await api.listOpenPullRequests(base)).slice().sort((left, right) =>
+        left.number - right.number
+    );
+    let scheduledState;
+    if (scheduled) {
+        const [comments, artifacts] = await Promise.all([
+            api.listRepositoryIssueComments(commentSince),
+            api.listRepositoryArtifacts()
+        ]);
+        scheduledState = groupScheduledState(pullRequests, comments, artifacts);
+    }
+    const openCandidates = phase === 'open' ? pullRequests.filter((pullRequest) =>
+        pullRequest.number > cursor
+    ).slice(0, batchSize) : [];
+    const decisions = await mapConcurrent(openCandidates, concurrency, async (listedPullRequest) => {
+        const comments = scheduled ? scheduledState.commentsByPullRequest.get(listedPullRequest.number) || [] : [];
+        const artifactName = previewArtifactName(listedPullRequest.number);
+        const artifacts = scheduled ? scheduledState.artifactsByName.get(artifactName) || [] : [];
+        if (!automaticBuildAllowed(listedPullRequest)) {
+            if (scheduled && requiresAuthorizationRevocation({
+                pullRequest: listedPullRequest,
+                comments,
+                artifacts
+            })) {
+                await dispatchRepositoryEvent(
+                    'refresh-pr-vsix',
+                    refreshPayload(pullRequestContext(listedPullRequest), 'approval-revoked')
+                );
+                return 'revoked';
+            }
+            return 'unsafe';
+        }
+        let cause = 'base-push';
+        if (scheduled) {
+            cause = scheduledRefreshCause({
+                pullRequest: listedPullRequest,
+                context: pullRequestContext(listedPullRequest),
+                comments,
+                artifacts,
+                now,
+                renewalWindowMs,
+                pendingWindowMs
+            });
+            if (!cause) {
+                return 'current';
+            }
+        }
+        const stable = await waitForStablePullRequest({
+            api,
+            pullRequestNumber: listedPullRequest.number,
+            expectedHeadSha: listedPullRequest.head.sha,
+            expectedBaseSha: listedPullRequest.base.sha,
+            retry: mergeRetry
+        });
+        if (stable.pullRequest.state !== 'open') {
+            return 'skipped';
+        }
+        if (!automaticBuildAllowed(stable.pullRequest)) {
+            return 'unsafe';
+        }
+        await dispatchRepositoryEvent('refresh-pr-vsix', refreshPayload(stable.context, cause));
+        return 'dispatched';
+    });
+    const closedCandidates = scheduled && phase === 'closed' ? scheduledState.closedCandidates.filter(
+        (pullRequestNumber) => pullRequestNumber > cursor
+    ).slice(0, batchSize) : [];
+    const closedDecisions = scheduled && phase === 'closed' ? await mapConcurrent(
+        closedCandidates,
+        concurrency,
+        async (pullRequestNumber) => {
+            const comments = scheduledState.commentsByPullRequest.get(pullRequestNumber) || [];
+            const artifacts = scheduledState.artifactsByName.get(previewArtifactName(pullRequestNumber)) || [];
+            if (!requiresClosedRepair(comments, artifacts)) {
+                return 'current';
+            }
+            const pullRequest = await api.getPullRequest(pullRequestNumber);
+            if (pullRequest.state !== 'closed') {
+                return 'skipped';
+            }
+            await dispatchRepositoryEvent(
+                'refresh-pr-vsix',
+                refreshPayload(pullRequestContext(pullRequest), 'closed-repair')
+            );
+            return 'repaired';
+        }
+    ) : [];
+    let continuation;
+    if (phase === 'open') {
+        const lastOpen = openCandidates[openCandidates.length - 1];
+        const remainingOpen = lastOpen && pullRequests.some((pullRequest) => pullRequest.number > lastOpen.number);
+        if (remainingOpen) {
+            continuation = Object.freeze({ phase: 'open', cursor: lastOpen.number });
+        } else if (scheduled && scheduledState.closedCandidates.length > 0) {
+            continuation = Object.freeze({ phase: 'closed', cursor: 0 });
+        }
+    } else {
+        const lastClosed = closedCandidates[closedCandidates.length - 1];
+        if (lastClosed !== undefined && scheduledState.closedCandidates.some((number) => number > lastClosed)) {
+            continuation = Object.freeze({ phase: 'closed', cursor: lastClosed });
+        }
+    }
+    return Object.freeze({
+        scanned: decisions.length,
+        dispatched: decisions.filter((decision) => decision === 'dispatched').length,
+        current: decisions.filter((decision) => decision === 'current').length,
+        skipped: decisions.filter((decision) => decision === 'skipped').length,
+        revoked: decisions.filter((decision) => decision === 'revoked').length,
+        unsafe: decisions.filter((decision) => decision === 'unsafe').length,
+        closedRepaired: closedDecisions.filter((decision) => decision === 'repaired').length,
+        ...(continuation ? { continuation } : {})
+    });
+}
+
+function workflowRunBaseBranch(event) {
+    const run = event && event.workflow_run;
+    const repository = event && event.repository;
+    if (event.action !== 'completed' || !run || run.name !== 'PR VSIX Base Event' ||
+        run.event !== 'push' || run.conclusion !== 'success' || !run.head_repository ||
+        !repository || run.head_repository.id !== repository.id) {
+        throw new PrVsixInvariantError('base event: expected a successful same-repository push workflow');
+    }
+    const branch = String(run.head_branch || '');
+    if (!branch || branch.includes('\n') || branch.includes('\r')) {
+        throw new PrVsixInvariantError('base event branch: expected a branch name');
+    }
+    return branch;
+}
+
+function continuationInvocation(event) {
+    const payload = event && event.client_payload;
+    if (event.action !== 'continue-pr-vsix-refresh' || !payload ||
+        typeof payload.scheduled !== 'boolean' ||
+        !['open', 'closed'].includes(payload.phase) ||
+        !Number.isSafeInteger(payload.cursor) || payload.cursor < 0 ||
+        (payload.scheduled ? payload.base !== '' : typeof payload.base !== 'string' || payload.base.length === 0) ||
+        (!payload.scheduled && payload.phase === 'closed')) {
+        throw new PrVsixInvariantError('refresh continuation: expected a valid trusted cursor payload');
+    }
+    return Object.freeze({
+        base: payload.base || undefined,
+        scheduled: payload.scheduled,
+        phase: payload.phase,
+        cursor: payload.cursor
+    });
+}
+
+async function main() {
+    if (!process.env.GITHUB_EVENT_PATH || !process.env.GITHUB_EVENT_NAME) {
+        throw new PrVsixInvariantError('GitHub event: expected payload path and event name');
+    }
+    const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+    const repository = event.repository && event.repository.full_name;
+    const invocation = process.env.GITHUB_EVENT_NAME === 'workflow_run' ? Object.freeze({
+        base: workflowRunBaseBranch(event),
+        scheduled: false,
+        phase: 'open',
+        cursor: 0
+    }) : process.env.GITHUB_EVENT_NAME === 'repository_dispatch' ? continuationInvocation(event) : Object.freeze({
+        base: undefined,
+        scheduled: true,
+        phase: 'open',
+        cursor: 0
+    });
+    const renewalDays = requirePositiveNumber(process.env.PR_VSIX_RENEWAL_DAYS, 'renewal days');
+    const retentionDays = requirePositiveNumber(
+        process.env.PR_VSIX_ARTIFACT_RETENTION_DAYS,
+        'artifact retention days'
+    );
+    const pendingHours = requirePositiveNumber(process.env.PR_VSIX_PENDING_HOURS, 'pending hours');
+    const concurrency = requirePositiveNumber(process.env.PR_VSIX_REFRESH_CONCURRENCY, 'refresh concurrency');
+    const mergeAttempts = requirePositiveNumber(process.env.PR_VSIX_MERGE_ATTEMPTS, 'merge attempts');
+    const mergeIntervalMs = Number(process.env.PR_VSIX_MERGE_INTERVAL_MS);
+    const dispatchIntervalMs = Number(process.env.PR_VSIX_DISPATCH_INTERVAL_MS);
+    const batchSize = Number(process.env.PR_VSIX_REFRESH_BATCH_SIZE);
+    if (!Number.isSafeInteger(concurrency) || !Number.isSafeInteger(mergeAttempts) ||
+        !Number.isSafeInteger(mergeIntervalMs) || mergeIntervalMs < 0 ||
+        !Number.isSafeInteger(dispatchIntervalMs) || dispatchIntervalMs < 0 ||
+        !Number.isSafeInteger(batchSize) || batchSize <= 0) {
+        throw new PrVsixInvariantError('refresh integers: expected valid concurrency and merge retry values');
+    }
+    const api = createGitHubApi({
+        token: process.env.GITHUB_TOKEN,
+        repository,
+        apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+        retry: apiRetryFromEnvironment()
+    });
+    const now = Date.now();
+    const dispatchRepositoryEvent = createDispatchScheduler(api, { intervalMs: dispatchIntervalMs });
+    const result = await refreshOpenPullRequests({
+        api,
+        base: invocation.base,
+        scheduled: invocation.scheduled,
+        now,
+        renewalWindowMs: renewalDays * 24 * 60 * 60 * 1000,
+        pendingWindowMs: pendingHours * 60 * 60 * 1000,
+        concurrency,
+        mergeRetry: { attempts: mergeAttempts, intervalMs: mergeIntervalMs },
+        commentSince: new Date(now - (retentionDays + 1) * 24 * 60 * 60 * 1000).toISOString(),
+        dispatchRepositoryEvent,
+        phase: invocation.phase,
+        cursor: invocation.cursor,
+        batchSize
+    });
+    if (result.continuation) {
+        await dispatchRepositoryEvent('continue-pr-vsix-refresh', {
+            scheduled: invocation.scheduled,
+            base: invocation.base || '',
+            phase: result.continuation.phase,
+            cursor: result.continuation.cursor
+        });
+    }
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+    main().catch((error) => {
+        process.stderr.write(`${error && error.stack ? error.stack : String(error)}\n`);
+        process.exitCode = 1;
+    });
+}
+
+export {
+    mapConcurrent,
+    createDispatchScheduler,
+    continuationInvocation,
+    groupScheduledState,
+    refreshOpenPullRequests,
+    refreshPayload,
+    requiresScheduledRefresh,
+    scheduledRefreshCause,
+    requiresAuthorizationRevocation,
+    requiresClosedRepair,
+    workflowRunBaseBranch
+};

--- a/scripts/ci/resolve-pr-vsix-context.mjs
+++ b/scripts/ci/resolve-pr-vsix-context.mjs
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    PrVsixInvariantError,
+    apiRetryFromEnvironment,
+    automaticBuildAllowed,
+    createGitHubApi,
+    pullRequestContext,
+    waitForStablePullRequest
+} from './sync-pr-vsix-comment.mjs';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const BUILD_CAUSES = new Set([
+    'approval-revoked',
+    'base-edited',
+    'base-push',
+    'closed-repair',
+    'labeled',
+    'manual',
+    'opened',
+    'renewal',
+    'reopened',
+    'repair',
+    'synchronize'
+]);
+const modulePath = fileURLToPath(import.meta.url);
+
+function requireEventRepository(event) {
+    const repository = event && event.repository && event.repository.full_name;
+    if (typeof repository !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+        throw new PrVsixInvariantError('repository: expected owner/name');
+    }
+    return repository;
+}
+
+function requireDispatchPayload(payload) {
+    if (!payload || !Number.isSafeInteger(payload.pull_request_number) || payload.pull_request_number <= 0 ||
+        !SHA_PATTERN.test(String(payload.head_sha || '')) || !SHA_PATTERN.test(String(payload.base_sha || '')) ||
+        !(payload.merge_sha === 'none' || SHA_PATTERN.test(String(payload.merge_sha || ''))) ||
+        !BUILD_CAUSES.has(payload.cause)) {
+        throw new PrVsixInvariantError('repository dispatch payload: expected PR, build SHAs, and cause');
+    }
+    return Object.freeze({
+        pullRequestNumber: payload.pull_request_number,
+        headSha: payload.head_sha,
+        baseSha: payload.base_sha,
+        mergeSha: payload.merge_sha,
+        cause: payload.cause
+    });
+}
+
+function contextEquals(left, right) {
+    return left.pullRequestNumber === right.pullRequestNumber && left.headSha === right.headSha &&
+        left.baseSha === right.baseSha && left.mergeSha === right.mergeSha;
+}
+
+async function resolveBuildContext({ event, api, mergeRetry }) {
+    const repository = requireEventRepository(event);
+    if (event.action !== 'refresh-pr-vsix' || !api) {
+        throw new PrVsixInvariantError('repository dispatch: expected refresh-pr-vsix and a GitHub API client');
+    }
+    const requested = requireDispatchPayload(event.client_payload);
+    if (requested.cause === 'approval-revoked' || requested.cause === 'closed-repair') {
+        const pullRequest = await api.getPullRequest(requested.pullRequestNumber);
+        const context = pullRequestContext(pullRequest);
+        const baseRepository = pullRequest.base && pullRequest.base.repo;
+        const cleanupRequired = requested.cause === 'approval-revoked' ?
+            pullRequest.state === 'open' && !automaticBuildAllowed(pullRequest) && contextEquals(requested, context) :
+            pullRequest.state === 'closed';
+        if (cleanupRequired && baseRepository && baseRepository.full_name === repository) {
+            return Object.freeze({
+                ...context,
+                checkoutSha: context.baseSha,
+                build: false,
+                isPullRequest: true
+            });
+        }
+        throw new PrVsixInvariantError(
+            `pull request ${requested.pullRequestNumber}: cleanup context is stale or inapplicable`
+        );
+    }
+    const stable = await waitForStablePullRequest({
+        api,
+        pullRequestNumber: requested.pullRequestNumber,
+        expectedHeadSha: requested.headSha,
+        expectedBaseSha: requested.baseSha,
+        retry: mergeRetry
+    });
+    if (!stable.buildable || !automaticBuildAllowed(stable.pullRequest) ||
+        !stable.pullRequest.base || !stable.pullRequest.base.repo ||
+        stable.pullRequest.base.repo.full_name !== repository || !contextEquals(requested, stable.context)) {
+        throw new PrVsixInvariantError(`pull request ${requested.pullRequestNumber}: refresh context is unauthorized, stale, or unmergeable`);
+    }
+    return Object.freeze({
+        ...stable.context,
+        checkoutSha: stable.context.mergeSha,
+        build: true,
+        isPullRequest: true
+    });
+}
+
+function renderOutputs(context) {
+    return [
+        `is-pull-request=${context.isPullRequest}`,
+        `build=${context.build}`,
+        `checkout-sha=${context.checkoutSha}`,
+        `pull-request-number=${context.pullRequestNumber}`,
+        `head-sha=${context.headSha}`,
+        `base-sha=${context.baseSha}`,
+        `merge-sha=${context.mergeSha}`
+    ].join('\n') + '\n';
+}
+
+async function main() {
+    if (!process.env.GITHUB_EVENT_PATH || !process.env.GITHUB_OUTPUT) {
+        throw new PrVsixInvariantError('GitHub files: expected event and output paths');
+    }
+    const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+    const repository = requireEventRepository(event);
+    const api = createGitHubApi({
+        token: process.env.GITHUB_TOKEN,
+        repository,
+        apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+        retry: apiRetryFromEnvironment()
+    });
+    const context = await resolveBuildContext({
+        event,
+        api,
+        mergeRetry: {
+            attempts: Number(process.env.PR_VSIX_MERGE_ATTEMPTS),
+            intervalMs: Number(process.env.PR_VSIX_MERGE_INTERVAL_MS)
+        }
+    });
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, renderOutputs(context), 'utf8');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+    main().catch((error) => {
+        process.stderr.write(`${error && error.stack ? error.stack : String(error)}\n`);
+        process.exitCode = 1;
+    });
+}
+
+export { contextEquals, renderOutputs, resolveBuildContext };

--- a/scripts/ci/sync-pr-vsix-comment.mjs
+++ b/scripts/ci/sync-pr-vsix-comment.mjs
@@ -1,0 +1,1283 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const API_VERSION = '2026-03-10';
+const BOT_LOGIN = 'github-actions[bot]';
+const COMMENT_MARKER = '<!-- better-todo-tree-pr-vsix';
+const ARTIFACT_NAME_PREFIX = 'better-todo-tree-pr-';
+const EXTERNAL_APPROVAL_REASON = 'External fork previews require maintainer approval with the `safe-to-test` label.';
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const CI_ACTIONS = new Set([
+    'approval-revoked',
+    'base-edited',
+    'base-push',
+    'closed-repair',
+    'labeled',
+    'manual',
+    'opened',
+    'renewal',
+    'reopened',
+    'repair',
+    'synchronize'
+]);
+const modulePath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(modulePath), '..', '..');
+const targetsPath = path.join(repoRoot, 'scripts', 'release', 'targets.json');
+
+class PrVsixInvariantError extends Error {
+    constructor(message, options) {
+        super(message, options && options.cause ? { cause: options.cause } : undefined);
+        this.name = 'PrVsixInvariantError';
+        this.status = options && options.status;
+        this.retryable = Boolean(options && options.retryable);
+        this.retryAfterMs = options && options.retryAfterMs;
+    }
+}
+
+function requireInteger(value, label) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new PrVsixInvariantError(`${label}: expected a positive integer`);
+    }
+    return value;
+}
+
+function requireSha(value, label) {
+    if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+        throw new PrVsixInvariantError(`${label}: expected a 40-character lowercase commit SHA`);
+    }
+    return value;
+}
+
+function requireMergeSha(value, label = 'merge SHA') {
+    if (value === 'none') {
+        return value;
+    }
+    return requireSha(value, label);
+}
+
+function requireRepository(value) {
+    if (typeof value !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+        throw new PrVsixInvariantError('repository: expected owner/name');
+    }
+    return value;
+}
+
+function timestamp(value, label) {
+    const parsed = Date.parse(value);
+    if (!Number.isFinite(parsed)) {
+        throw new PrVsixInvariantError(`${label}: expected an ISO-8601 timestamp`);
+    }
+    return parsed;
+}
+
+function requireWorkflowRun(run) {
+    if (!run) {
+        throw new PrVsixInvariantError('workflow run: expected metadata');
+    }
+
+    const createdAt = String(run.created_at || '');
+    const startedAt = String(run.run_started_at || run.created_at || '');
+    const updatedAt = String(run.updated_at || '');
+    timestamp(createdAt, 'workflow run creation time');
+    timestamp(startedAt, 'workflow run start time');
+    timestamp(updatedAt, 'workflow run update time');
+    return Object.freeze({
+        id: requireInteger(run.id, 'workflow run id'),
+        runAttempt: requireInteger(run.run_attempt, 'workflow run attempt'),
+        runNumber: requireInteger(run.run_number, 'workflow run number'),
+        workflowId: requireInteger(run.workflow_id, 'workflow id'),
+        workflowHeadSha: requireSha(run.head_sha, 'workflow run head SHA'),
+        headRepositoryId: run.head_repository ? requireInteger(run.head_repository.id, 'head repository id') : undefined,
+        createdAt,
+        startedAt,
+        updatedAt,
+        displayTitle: String(run.display_title || ''),
+        event: String(run.event || ''),
+        name: String(run.name || ''),
+        status: String(run.status || ''),
+        conclusion: String(run.conclusion || ''),
+        pullRequestNumbers: Array.isArray(run.pull_requests) ? run.pull_requests.map((pullRequest) =>
+            requireInteger(pullRequest.number, 'workflow run pull request number')
+        ) : []
+    });
+}
+
+function previewArtifactName(pullRequestNumber) {
+    return `${ARTIFACT_NAME_PREFIX}${requireInteger(pullRequestNumber, 'pull request number')}.vsix`;
+}
+
+function parseCiRunName(displayTitle) {
+    const match = String(displayTitle || '').match(
+        /^PR VSIX Build PR #([1-9][0-9]*) head ([0-9a-f]{40}) base ([0-9a-f]{40}) merge ([0-9a-f]{40}|none) action ([a-z-]+)$/
+    );
+    if (!match) {
+        return undefined;
+    }
+    return Object.freeze({
+        pullRequestNumber: Number(match[1]),
+        headSha: match[2],
+        baseSha: match[3],
+        mergeSha: match[4],
+        action: match[5]
+    });
+}
+
+function parseLifecycleRunName(displayTitle) {
+    const match = String(displayTitle || '').match(
+        /^PR VSIX Event #([1-9][0-9]*) (closed|edited|labeled|unlabeled|opened|reopened|synchronize)$/
+    );
+    return match ? Object.freeze({ pullRequestNumber: Number(match[1]), action: match[2] }) : undefined;
+}
+
+function parseLifecycleArtifactName(name) {
+    const match = String(name || '').match(
+        /^better-todo-tree-pr-vsix-event-([1-9][0-9]*)-head-([0-9a-f]{40})-base-([0-9a-f]{40})-merge-([0-9a-f]{40}|none)-(closed|edited|labeled|unlabeled|opened|reopened|synchronize)-run-([1-9][0-9]*)-attempt-([1-9][0-9]*)$/
+    );
+    return match ? Object.freeze({
+        pullRequestNumber: Number(match[1]),
+        headSha: match[2],
+        baseSha: match[3],
+        mergeSha: match[4],
+        action: match[5],
+        runId: Number(match[6]),
+        runAttempt: Number(match[7])
+    }) : undefined;
+}
+
+function artifactUrl(repository, runId, artifactId) {
+    return `https://github.com/${requireRepository(repository)}/actions/runs/${requireInteger(runId, 'workflow run id')}/artifacts/${requireInteger(artifactId, 'artifact id')}`;
+}
+
+function runUrl(repository, runId) {
+    return `https://github.com/${requireRepository(repository)}/actions/runs/${requireInteger(runId, 'workflow run id')}`;
+}
+
+function commitUrl(repository, sha) {
+    return `https://github.com/${requireRepository(repository)}/commit/${requireSha(sha, 'commit SHA')}`;
+}
+
+function renderMarker(run, artifact) {
+    return [
+        COMMENT_MARKER,
+        `source: ${run.source}`,
+        `action: ${run.action}`,
+        `run-id: ${run.id}`,
+        `run-attempt: ${run.runAttempt}`,
+        `run-number: ${run.runNumber}`,
+        `observed-at: ${run.startedAt}`,
+        `head-sha: ${run.headSha}`,
+        `base-sha: ${run.baseSha}`,
+        `merge-sha: ${run.mergeSha}`,
+        `phase: ${run.phase}`,
+        `conclusion: ${run.conclusion || 'none'}`,
+        `artifact-id: ${artifact ? artifact.id : 'none'}`,
+        `artifact-name: ${artifact ? artifact.name : 'none'}`,
+        '-->'
+    ].join('\n');
+}
+
+function parseCommentMetadata(body) {
+    if (typeof body !== 'string' || !body.includes(COMMENT_MARKER)) {
+        return undefined;
+    }
+
+    const patterns = {
+        source: /source: (ci|lifecycle)/,
+        action: /action: ([a-z-]+)/,
+        runId: /run-id: ([1-9][0-9]*)/,
+        runAttempt: /run-attempt: ([1-9][0-9]*)/,
+        runNumber: /run-number: ([1-9][0-9]*)/,
+        startedAt: /observed-at: ([^\n]+)/,
+        headSha: /head-sha: ([0-9a-f]{40})/,
+        baseSha: /base-sha: ([0-9a-f]{40})/,
+        mergeSha: /merge-sha: ([0-9a-f]{40}|none)/,
+        phase: /phase: (blocked|closed|completed|pending|provisional|transitioning)/,
+        conclusion: /conclusion: ([a-z_]+|none)/,
+        artifactId: /artifact-id: ([1-9][0-9]*|none)/,
+        artifactName: /artifact-name: ([A-Za-z0-9._-]+|none)/
+    };
+    const matches = Object.fromEntries(Object.entries(patterns).map(([key, pattern]) => [key, body.match(pattern)]));
+    if (!matches.runId || !matches.runAttempt) {
+        return undefined;
+    }
+
+    return Object.freeze({
+        source: matches.source && matches.source[1],
+        action: matches.action && matches.action[1],
+        runId: Number(matches.runId[1]),
+        runAttempt: Number(matches.runAttempt[1]),
+        runNumber: matches.runNumber ? Number(matches.runNumber[1]) : undefined,
+        startedAt: matches.startedAt && matches.startedAt[1],
+        headSha: matches.headSha && matches.headSha[1],
+        baseSha: matches.baseSha && matches.baseSha[1],
+        mergeSha: matches.mergeSha && matches.mergeSha[1],
+        phase: matches.phase && matches.phase[1],
+        conclusion: matches.conclusion && matches.conclusion[1] !== 'none' ? matches.conclusion[1] : undefined,
+        artifactId: matches.artifactId && matches.artifactId[1] !== 'none' ? Number(matches.artifactId[1]) : undefined,
+        artifactName: matches.artifactName && matches.artifactName[1] !== 'none' ? matches.artifactName[1] : undefined
+    });
+}
+
+function compareSequence(left, right) {
+    if (left.runNumber !== right.runNumber) {
+        return left.runNumber - right.runNumber;
+    }
+    return left.runAttempt - right.runAttempt;
+}
+
+function contextMatches(left, right) {
+    return left.headSha === right.headSha && left.baseSha === right.baseSha && left.mergeSha === right.mergeSha;
+}
+
+function phaseRank(phase) {
+    return phase === 'completed' ? 2 : 1;
+}
+
+function existingStateDominates(existing, incoming) {
+    if (!existing.source || !existing.runNumber || !existing.startedAt || !existing.baseSha || !existing.mergeSha ||
+        !contextMatches(existing, incoming) || incoming.phase === 'closed' || existing.phase === 'closed') {
+        return false;
+    }
+    if (existing.source === 'ci' && incoming.source === 'ci') {
+        const generation = compareSequence(existing, incoming);
+        return generation > 0 || generation === 0 && phaseRank(existing.phase) > phaseRank(incoming.phase);
+    }
+    const sameAction = existing.action && existing.action === incoming.action;
+    if (sameAction && existing.source === 'ci' && incoming.source === 'lifecycle' &&
+        existing.phase === 'completed' && incoming.phase !== 'blocked') {
+        return true;
+    }
+    if (sameAction && existing.source === 'lifecycle' && incoming.source === 'ci' &&
+        incoming.phase === 'completed' && existing.phase !== 'blocked') {
+        return false;
+    }
+
+    const observed = timestamp(existing.startedAt, 'comment observation time') -
+        timestamp(incoming.startedAt, 'workflow observation time');
+    if (observed !== 0) {
+        return observed > 0;
+    }
+    if (existing.source !== incoming.source) {
+        return existing.source === 'ci';
+    }
+    return compareSequence(existing, incoming) > 0;
+}
+
+function isArtifactForRun(artifact, run, pullRequestNumber) {
+    const createdAt = artifact && timestamp(artifact.created_at, 'artifact creation time');
+    return artifact && artifact.name === previewArtifactName(pullRequestNumber) &&
+        artifact.workflow_run && artifact.workflow_run.id === run.id &&
+        artifact.workflow_run.head_sha === run.workflowHeadSha &&
+        createdAt >= timestamp(run.startedAt, 'workflow run start time') &&
+        (run.status !== 'completed' || createdAt <= timestamp(run.updatedAt, 'workflow run update time'));
+}
+
+function isCurrentArtifact(artifact, run, pullRequestNumber) {
+    return isArtifactForRun(artifact, run, pullRequestNumber) && !artifact.expired &&
+        Number.isSafeInteger(artifact.size_in_bytes) && artifact.size_in_bytes > 0 &&
+        DIGEST_PATTERN.test(String(artifact.digest || '')) &&
+        Number.isFinite(timestamp(artifact.expires_at, 'artifact expiry time'));
+}
+
+function renderReadyComment({ repository, run, artifact, targets }) {
+    if (!isCurrentArtifact(artifact, run, run.pullRequestNumber)) {
+        throw new PrVsixInvariantError('artifact: expected a current SHA-256-addressed artifact');
+    }
+    if (!Array.isArray(targets) || targets.length === 0) {
+        throw new PrVsixInvariantError('targets: expected a non-empty target list');
+    }
+
+    const desktopTargets = targets.filter((target) => target !== 'web');
+    return [
+        renderMarker(run, artifact),
+        '### PR VSIX: ready',
+        '',
+        `Full CI passed for [\`${run.headSha.slice(0, 12)}\`](${commitUrl(repository, run.headSha)}).`,
+        '',
+        `[Download the cross-platform VSIX](${artifactUrl(repository, run.id, artifact.id)})`,
+        '',
+        '**Security:** This VSIX contains unreviewed code from this pull request. Use an isolated VS Code profile and a disposable test workspace without production credentials.',
+        '',
+        `Desktop targets: ${desktopTargets.map((target) => `\`${target}\``).join(', ')}`,
+        '',
+        `Artifact digest: \`${artifact.digest}\`  `,
+        `Expires: \`${artifact.expires_at}\``,
+        '',
+        'Installation:',
+        '1. Download the `.vsix` file while signed in to GitHub.',
+        '2. Run `Profiles: Create a Temporary Profile` from the VS Code Command Palette.',
+        '3. Open a disposable test workspace without production credentials.',
+        '4. Run `Extensions: Install from VSIX...` from the Command Palette.',
+        '',
+        `[Workflow run](${runUrl(repository, run.id)})`
+    ].join('\n');
+}
+
+function renderUnavailableComment({ repository, run, reason }) {
+    return [
+        renderMarker(run),
+        '### PR VSIX: unavailable',
+        '',
+        `No installable bundle matches [\`${run.headSha.slice(0, 12)}\`](${commitUrl(repository, run.headSha)}).`,
+        '',
+        `Reason: ${reason}`,
+        '',
+        `[Workflow run](${runUrl(repository, run.id)})`
+    ].join('\n');
+}
+
+function renderPendingComment({ repository, run }) {
+    return [
+        renderMarker(run),
+        '### PR VSIX: building',
+        '',
+        `CI is testing [\`${run.headSha.slice(0, 12)}\`](${commitUrl(repository, run.headSha)}).`,
+        '',
+        'The download link remains withheld until every test, bundle, package, and archive check passes.'
+    ].join('\n');
+}
+
+function renderTransitionComment({ repository, run }) {
+    const transitionRun = Object.freeze({ ...run, phase: 'transitioning' });
+    return [
+        renderMarker(transitionRun),
+        '### PR VSIX: preparing',
+        '',
+        `Full CI passed for [\`${run.headSha.slice(0, 12)}\`](${commitUrl(repository, run.headSha)}).`,
+        '',
+        'The verified download link is being synchronized.'
+    ].join('\n');
+}
+
+function renderClosedComment({ repository, run }) {
+    return [
+        renderMarker(run),
+        '### PR VSIX: unavailable',
+        '',
+        `The artifact for [\`${run.headSha.slice(0, 12)}\`](${commitUrl(repository, run.headSha)}) was removed when the pull request closed.`
+    ].join('\n');
+}
+
+function requireWorkflowSelector(value) {
+    if (Number.isSafeInteger(value)) {
+        return String(requireInteger(value, 'workflow id'));
+    }
+    if (typeof value === 'string' && /^[A-Za-z0-9._-]+\.ya?ml$/.test(value)) {
+        return encodeURIComponent(value);
+    }
+    throw new PrVsixInvariantError('workflow selector: expected an id or workflow filename');
+}
+
+function workflowRunQuery(filters = {}) {
+    const parameters = [];
+    if (filters.event) {
+        if (!['pull_request', 'repository_dispatch'].includes(filters.event)) {
+            throw new PrVsixInvariantError('workflow run event filter: unsupported event');
+        }
+        parameters.push(['event', filters.event]);
+    }
+    if (filters.headSha) {
+        parameters.push(['head_sha', requireSha(filters.headSha, 'workflow run filter head SHA')]);
+    }
+    if (filters.createdAfter) {
+        timestamp(filters.createdAfter, 'workflow run creation lower bound');
+        parameters.push(['created', `>=${filters.createdAfter}`]);
+    }
+    return parameters.length === 0 ? '' : `?${parameters.map(([key, value]) =>
+        `${key}=${encodeURIComponent(value)}`
+    ).join('&')}`;
+}
+
+function requireApiRetryOptions(options = {}) {
+    const retry = {
+        attempts: options.attempts === undefined ? 1 : Number(options.attempts),
+        baseDelayMs: options.baseDelayMs === undefined ? 0 : Number(options.baseDelayMs),
+        maxDelayMs: options.maxDelayMs === undefined ? 0 : Number(options.maxDelayMs),
+        now: options.now || Date.now,
+        sleep: options.sleep || ((delay) => new Promise((resolve) => setTimeout(resolve, delay)))
+    };
+    if (!Number.isSafeInteger(retry.attempts) || retry.attempts <= 0 ||
+        !Number.isSafeInteger(retry.baseDelayMs) || retry.baseDelayMs < 0 ||
+        !Number.isSafeInteger(retry.maxDelayMs) || retry.maxDelayMs < retry.baseDelayMs ||
+        typeof retry.now !== 'function' || typeof retry.sleep !== 'function') {
+        throw new PrVsixInvariantError('API retry policy: expected positive attempts and valid delays');
+    }
+    return Object.freeze(retry);
+}
+
+function apiRetryFromEnvironment(environment = process.env) {
+    return requireApiRetryOptions({
+        attempts: environment.PR_VSIX_API_RETRY_ATTEMPTS,
+        baseDelayMs: environment.PR_VSIX_API_RETRY_BASE_MS,
+        maxDelayMs: environment.PR_VSIX_API_RETRY_MAX_MS
+    });
+}
+
+function responseRetryAfterMs(response, now) {
+    const retryAfter = response.headers.get('retry-after');
+    if (retryAfter) {
+        const seconds = Number(retryAfter);
+        if (Number.isFinite(seconds) && seconds >= 0) {
+            return Math.ceil(seconds * 1000);
+        }
+        const date = Date.parse(retryAfter);
+        if (Number.isFinite(date)) {
+            return Math.max(0, date - now());
+        }
+    }
+    const remaining = response.headers.get('x-ratelimit-remaining');
+    const reset = Number(response.headers.get('x-ratelimit-reset'));
+    if (remaining === '0' && Number.isFinite(reset)) {
+        return Math.max(0, reset * 1000 - now()) + 1000;
+    }
+    return response.status === 403 || response.status === 429 ? 60000 : undefined;
+}
+
+function createGitHubApi({
+    token,
+    repository,
+    apiUrl = 'https://api.github.com',
+    fetchImpl = globalThis.fetch,
+    retry
+}) {
+    if (typeof token !== 'string' || token.length === 0) {
+        throw new PrVsixInvariantError('GITHUB_TOKEN: expected a non-empty token');
+    }
+    if (typeof fetchImpl !== 'function') {
+        throw new PrVsixInvariantError('fetch implementation: expected a function');
+    }
+
+    const [owner, name] = requireRepository(repository).split('/');
+    const repositoryPath = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+    const retryOptions = requireApiRetryOptions(retry);
+    let rateLimitUntil = 0;
+    let rateLimitGate = Promise.resolve();
+
+    function blockForRateLimit(delay) {
+        const blockedUntil = retryOptions.now() + delay;
+        if (blockedUntil <= rateLimitUntil) {
+            return rateLimitGate;
+        }
+        rateLimitUntil = blockedUntil;
+        rateLimitGate = rateLimitGate.then(async () => {
+            const remaining = Math.max(0, rateLimitUntil - retryOptions.now());
+            if (remaining > 0) {
+                await retryOptions.sleep(remaining);
+            }
+        });
+        return rateLimitGate;
+    }
+
+    async function requestOnce(relativePath, { method = 'GET', body, expectedStatuses = [200] } = {}) {
+        let response;
+        try {
+            response = await fetchImpl(`${apiUrl}${relativePath}`, {
+                method,
+                headers: {
+                    Accept: 'application/vnd.github+json',
+                    Authorization: `Bearer ${token}`,
+                    'User-Agent': 'better-todo-tree-pr-vsix',
+                    'X-GitHub-Api-Version': API_VERSION,
+                    ...(body === undefined ? {} : { 'Content-Type': 'application/json' })
+                },
+                body: body === undefined ? undefined : JSON.stringify(body)
+            });
+        } catch (cause) {
+            throw new PrVsixInvariantError(`GitHub API ${method} ${relativePath}: request failed`, {
+                cause,
+                retryable: true
+            });
+        }
+        const responseText = await response.text();
+        function httpError(detail, cause) {
+            const normalizedDetail = String(detail).toLowerCase();
+            const rateLimited = response.status === 429 || response.status === 403 &&
+                (response.headers.has('retry-after') || response.headers.get('x-ratelimit-remaining') === '0' ||
+                normalizedDetail.includes('rate limit') || normalizedDetail.includes('abuse detection'));
+            const retryable = rateLimited || [500, 502, 503, 504].includes(response.status);
+            return new PrVsixInvariantError(
+                `GitHub API ${method} ${relativePath}: HTTP ${response.status}: ${detail}`,
+                {
+                    cause,
+                    status: response.status,
+                    retryable,
+                    retryAfterMs: rateLimited ? responseRetryAfterMs(response, retryOptions.now) : undefined
+                }
+            );
+        }
+        let responseBody;
+        try {
+            responseBody = responseText.length === 0 ? undefined : JSON.parse(responseText);
+        } catch (cause) {
+            if (!expectedStatuses.includes(response.status)) {
+                throw httpError(responseText.slice(0, 1000), cause);
+            }
+            throw new PrVsixInvariantError(`GitHub API ${method} ${relativePath}: invalid JSON response`, { cause });
+        }
+
+        if (!expectedStatuses.includes(response.status)) {
+            const detail = responseBody && responseBody.message ? responseBody.message : responseText.slice(0, 1000);
+            throw httpError(detail);
+        }
+        return responseBody;
+    }
+
+    async function request(relativePath, options) {
+        for (let attempt = 1; attempt <= retryOptions.attempts; attempt += 1) {
+            await rateLimitGate;
+            try {
+                return await requestOnce(relativePath, options);
+            } catch (error) {
+                const rateLimitDelay = error instanceof PrVsixInvariantError &&
+                    Number.isFinite(error.retryAfterMs) ? error.retryAfterMs : 0;
+                const rateLimitWait = rateLimitDelay > 0 ? blockForRateLimit(rateLimitDelay) : undefined;
+                if (!(error instanceof PrVsixInvariantError) || !error.retryable ||
+                    attempt === retryOptions.attempts) {
+                    throw error;
+                }
+                const exponentialDelay = Math.min(
+                    retryOptions.maxDelayMs,
+                    retryOptions.baseDelayMs * 2 ** (attempt - 1)
+                );
+                if (rateLimitWait) {
+                    await rateLimitWait;
+                } else if (exponentialDelay > 0) {
+                    await retryOptions.sleep(exponentialDelay);
+                }
+            }
+        }
+        throw new PrVsixInvariantError('GitHub API retry policy: unreachable state');
+    }
+
+    async function listPaginated(relativePath, property) {
+        const separator = relativePath.includes('?') ? '&' : '?';
+        const values = [];
+        let page = 1;
+        while (true) {
+            const responseBody = await request(`${relativePath}${separator}per_page=100&page=${page}`);
+            const pageValues = property === undefined ? responseBody : responseBody && responseBody[property];
+            if (!Array.isArray(pageValues)) {
+                throw new PrVsixInvariantError(`GitHub API ${relativePath}: expected a paginated array`);
+            }
+            values.push(...pageValues);
+            if (pageValues.length < 100) {
+                return values;
+            }
+            page += 1;
+        }
+    }
+
+    return Object.freeze({
+        getPullRequest(number) {
+            return request(`${repositoryPath}/pulls/${requireInteger(number, 'pull request number')}`);
+        },
+        getCommit(sha) {
+            return request(`${repositoryPath}/commits/${requireSha(sha, 'commit SHA')}`);
+        },
+        listOpenPullRequests(base) {
+            const baseQuery = base ? `&base=${encodeURIComponent(base)}` : '';
+            return listPaginated(`${repositoryPath}/pulls?state=open${baseQuery}`);
+        },
+        listRunArtifacts(runId) {
+            return listPaginated(`${repositoryPath}/actions/runs/${requireInteger(runId, 'workflow run id')}/artifacts`, 'artifacts');
+        },
+        listWorkflowRuns(workflow, filters) {
+            return listPaginated(
+                `${repositoryPath}/actions/workflows/${requireWorkflowSelector(workflow)}/runs${workflowRunQuery(filters)}`,
+                'workflow_runs'
+            );
+        },
+        listArtifactsByName(nameValue) {
+            return listPaginated(`${repositoryPath}/actions/artifacts?name=${encodeURIComponent(nameValue)}`, 'artifacts');
+        },
+        listRepositoryArtifacts() {
+            return listPaginated(`${repositoryPath}/actions/artifacts`, 'artifacts');
+        },
+        deleteArtifact(artifactId) {
+            return request(`${repositoryPath}/actions/artifacts/${requireInteger(artifactId, 'artifact id')}`, {
+                method: 'DELETE',
+                expectedStatuses: [204, 404]
+            });
+        },
+        listIssueComments(number) {
+            return listPaginated(`${repositoryPath}/issues/${requireInteger(number, 'pull request number')}/comments`);
+        },
+        listRepositoryIssueComments(since) {
+            timestamp(since, 'repository issue comment lower bound');
+            return listPaginated(
+                `${repositoryPath}/issues/comments?sort=updated&direction=desc&since=${encodeURIComponent(since)}`
+            );
+        },
+        createIssueComment(number, body) {
+            return request(`${repositoryPath}/issues/${requireInteger(number, 'pull request number')}/comments`, {
+                method: 'POST',
+                body: { body },
+                expectedStatuses: [201]
+            });
+        },
+        updateIssueComment(commentId, body) {
+            return request(`${repositoryPath}/issues/comments/${requireInteger(commentId, 'comment id')}`, {
+                method: 'PATCH',
+                body: { body }
+            });
+        },
+        deleteIssueComment(commentId) {
+            return request(`${repositoryPath}/issues/comments/${requireInteger(commentId, 'comment id')}`, {
+                method: 'DELETE',
+                expectedStatuses: [204, 404]
+            });
+        },
+        dispatchRepositoryEvent(eventType, clientPayload) {
+            if (typeof eventType !== 'string' || !/^[A-Za-z0-9_-]+$/.test(eventType)) {
+                throw new PrVsixInvariantError('repository dispatch event type: expected a portable identifier');
+            }
+            return request(`${repositoryPath}/dispatches`, {
+                method: 'POST',
+                body: { event_type: eventType, client_payload: clientPayload },
+                expectedStatuses: [204]
+            });
+        }
+    });
+}
+
+function normalizedMergeSha(pullRequest) {
+    if (pullRequest && (pullRequest.mergeable === false || pullRequest.mergeable_state === 'dirty')) {
+        return 'none';
+    }
+    return pullRequest && SHA_PATTERN.test(String(pullRequest.merge_commit_sha || '')) ?
+        pullRequest.merge_commit_sha : 'none';
+}
+
+function pullRequestContext(pullRequest) {
+    return Object.freeze({
+        pullRequestNumber: requireInteger(pullRequest.number, 'pull request number'),
+        headSha: requireSha(pullRequest.head && pullRequest.head.sha, 'pull request head SHA'),
+        baseSha: requireSha(pullRequest.base && pullRequest.base.sha, 'pull request base SHA'),
+        mergeSha: requireMergeSha(normalizedMergeSha(pullRequest))
+    });
+}
+
+function automaticBuildAllowed(pullRequest) {
+    const association = String(pullRequest.author_association || '');
+    const labels = Array.isArray(pullRequest.labels) ? pullRequest.labels : [];
+    return pullRequest.head && pullRequest.head.repo && pullRequest.base && pullRequest.base.repo &&
+        (pullRequest.head.repo.id === pullRequest.base.repo.id ||
+        ['COLLABORATOR', 'MEMBER', 'OWNER'].includes(association) ||
+        labels.some((label) => label && label.name === 'safe-to-test'));
+}
+
+function mergeCommitMatchesContext(commit, context) {
+    const parents = commit && Array.isArray(commit.parents) ? commit.parents.map((parent) => parent.sha) : [];
+    return parents.length === 2 && new Set(parents).size === 2 &&
+        parents.includes(context.baseSha) && parents.includes(context.headSha);
+}
+
+function requireMergeRetry(options) {
+    if (!options || !Number.isSafeInteger(options.attempts) || options.attempts <= 0 ||
+        !Number.isSafeInteger(options.intervalMs) || options.intervalMs < 0) {
+        throw new PrVsixInvariantError('merge retry: expected positive attempts and a non-negative interval');
+    }
+    return options;
+}
+
+async function waitForStablePullRequest({ api, pullRequestNumber, expectedHeadSha, expectedBaseSha, retry }) {
+    const options = requireMergeRetry(retry);
+    for (let attempt = 1; attempt <= options.attempts; attempt += 1) {
+        const pullRequest = await api.getPullRequest(pullRequestNumber);
+        const context = pullRequestContext(pullRequest);
+        if (expectedHeadSha && context.headSha !== expectedHeadSha ||
+            expectedBaseSha && context.baseSha !== expectedBaseSha) {
+            throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: build context changed during reconciliation`);
+        }
+        if (pullRequest.state !== 'open') {
+            return Object.freeze({ pullRequest, context, buildable: false });
+        }
+        if (pullRequest.mergeable === false || pullRequest.mergeable_state === 'dirty') {
+            return Object.freeze({
+                pullRequest,
+                context: Object.freeze({ ...context, mergeSha: 'none' }),
+                buildable: false
+            });
+        }
+        if (pullRequest.mergeable === true && context.mergeSha !== 'none') {
+            const mergeCommit = await api.getCommit(context.mergeSha);
+            if (mergeCommitMatchesContext(mergeCommit, context)) {
+                return Object.freeze({ pullRequest, context, buildable: true });
+            }
+        }
+        if (attempt < options.attempts) {
+            await new Promise((resolve) => setTimeout(resolve, options.intervalMs));
+        }
+    }
+    throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: merge context did not stabilize`);
+}
+
+function runMatchesPullRequest(run, pullRequest, repository) {
+    const context = pullRequestContext(pullRequest);
+    const baseRepository = pullRequest.base && pullRequest.base.repo;
+    const runCreatedAt = timestamp(run.createdAt, 'workflow run creation time');
+    const closedRepair = run.action === 'closed-repair' && pullRequest.state === 'closed';
+    const temporal = timestamp(pullRequest.created_at, 'pull request creation time') <= runCreatedAt &&
+        (closedRepair || !pullRequest.closed_at || runCreatedAt <=
+            timestamp(pullRequest.closed_at, 'pull request close time'));
+    const sourceMatches = run.event === 'repository_dispatch' && baseRepository &&
+        baseRepository.id === run.headRepositoryId;
+
+    return run.pullRequestNumber === pullRequest.number && baseRepository &&
+        baseRepository.full_name === repository && sourceMatches && temporal &&
+        (closedRepair || contextMatches(context, run));
+}
+
+function ciRunFromRaw(rawRun) {
+    const workflowRun = requireWorkflowRun(rawRun);
+    const context = parseCiRunName(workflowRun.displayTitle);
+    if (!context || !CI_ACTIONS.has(context.action)) {
+        return undefined;
+    }
+    return Object.freeze({ ...workflowRun, ...context, source: 'ci' });
+}
+
+async function associatedPullRequest(api, workflowRun, repository) {
+    const context = parseCiRunName(workflowRun.displayTitle);
+    if (!context) {
+        throw new PrVsixInvariantError(`workflow run ${workflowRun.id}: missing canonical PR run name`);
+    }
+    const pullRequest = await api.getPullRequest(context.pullRequestNumber);
+    return runMatchesPullRequest({ ...workflowRun, ...context }, pullRequest, repository) ? pullRequest : undefined;
+}
+
+async function latestCiRun(api, workflow, pullRequest, repository, options = {}) {
+    const context = pullRequestContext(pullRequest);
+    const defaultBase = pullRequest.base && pullRequest.base.repo &&
+        pullRequest.base.ref === pullRequest.base.repo.default_branch;
+    const runs = await api.listWorkflowRuns(workflow, {
+        event: 'repository_dispatch',
+        headSha: defaultBase && !options.omitHeadSha ? context.baseSha : undefined,
+        createdAfter: options.createdAfter
+    });
+    const matching = runs.map(ciRunFromRaw).filter((run) =>
+        run && (!options.actions || options.actions.has(run.action)) &&
+        runMatchesPullRequest(run, pullRequest, repository)
+    );
+    return matching.reduce((candidate, run) =>
+        !candidate || compareSequence(run, candidate) > 0 ? run : candidate
+    , undefined);
+}
+
+async function upsertComment(
+    api,
+    pullRequestNumber,
+    body,
+    run,
+    prepare = async () => 0,
+    transitionBody
+) {
+    const comments = await api.listIssueComments(pullRequestNumber);
+    const managed = comments.filter((comment) =>
+        comment && comment.user && comment.user.login === BOT_LOGIN &&
+        typeof comment.body === 'string' && comment.body.includes(COMMENT_MARKER)
+    ).sort((left, right) => left.id - right.id);
+    if (managed.some((comment) => {
+        const metadata = parseCommentMetadata(comment.body);
+        return metadata && existingStateDominates(metadata, run);
+    })) {
+        return Object.freeze({ applied: false, removedArtifacts: 0 });
+    }
+
+    const primary = managed[0];
+    const alreadyFinal = primary && primary.body === body;
+    const initialBody = alreadyFinal ? body : transitionBody || body;
+    let commentId;
+    if (!primary) {
+        const created = await api.createIssueComment(pullRequestNumber, initialBody);
+        commentId = created.id;
+    } else {
+        commentId = primary.id;
+        if (primary.body !== initialBody) {
+            await api.updateIssueComment(primary.id, initialBody);
+        }
+    }
+    await Promise.all(managed.slice(primary ? 1 : 0).map((comment) => api.deleteIssueComment(comment.id)));
+    const removedArtifacts = await prepare();
+    if (!alreadyFinal && transitionBody && transitionBody !== body) {
+        await api.updateIssueComment(commentId, body);
+    }
+    return Object.freeze({ applied: true, commentId, removedArtifacts });
+}
+
+async function removePreviewArtifacts(api, pullRequestNumber, retainedArtifactId, retainedRun) {
+    const name = previewArtifactName(pullRequestNumber);
+    const artifacts = await api.listArtifactsByName(name);
+    const removals = artifacts.filter((artifact) => {
+        if (artifact.name !== name) {
+            throw new PrVsixInvariantError(`artifact ${artifact.id}: managed name mismatch`);
+        }
+        if (artifact.id === retainedArtifactId) {
+            return false;
+        }
+        if (!retainedRun) {
+            return true;
+        }
+        if (artifact.workflow_run && artifact.workflow_run.id === retainedRun.id) {
+            if (retainedRun.status !== 'completed' && isArtifactForRun(artifact, retainedRun, pullRequestNumber)) {
+                return false;
+            }
+            return timestamp(artifact.created_at, 'artifact creation time') <=
+                timestamp(retainedRun.updatedAt, 'workflow run update time');
+        }
+        return timestamp(artifact.created_at, 'artifact creation time') <
+            timestamp(retainedRun.createdAt, 'workflow run creation time');
+    });
+    await Promise.all(removals.map((artifact) => api.deleteArtifact(artifact.id)));
+    return removals.length;
+}
+
+async function removeRunArtifacts(api, artifacts, run, pullRequestNumber) {
+    const removals = artifacts.filter((artifact) => isArtifactForRun(artifact, run, pullRequestNumber));
+    await Promise.all(removals.map((artifact) => api.deleteArtifact(artifact.id)));
+    return removals.length;
+}
+
+async function synchronizeCompletedRun({ api, repository, run, pullRequest, artifacts, targets }) {
+    const name = previewArtifactName(pullRequest.number);
+    const matches = artifacts.filter((artifact) => isCurrentArtifact(artifact, run, pullRequest.number));
+    let body;
+    let retainedArtifact;
+    let invariantError;
+    if (run.conclusion === 'success' && matches.length === 1) {
+        retainedArtifact = matches[0];
+        body = renderReadyComment({ repository, run, artifact: retainedArtifact, targets });
+    } else if (run.conclusion === 'success') {
+        body = renderUnavailableComment({
+            repository,
+            run,
+            reason: `CI succeeded, but the run produced ${matches.length} current artifacts named \`${name}\`.`
+        });
+        invariantError = new PrVsixInvariantError(`workflow run ${run.id}: expected one ${name} artifact, found ${matches.length}`);
+    } else {
+        body = renderUnavailableComment({
+            repository,
+            run,
+            reason: `CI concluded with \`${run.conclusion || 'unknown'}\`.`
+        });
+    }
+
+    const comment = await upsertComment(
+        api,
+        pullRequest.number,
+        body,
+        run,
+        () => removePreviewArtifacts(api, pullRequest.number, retainedArtifact && retainedArtifact.id, run),
+        retainedArtifact ? renderTransitionComment({ repository, run }) : undefined
+    );
+    if (!comment.applied) {
+        const removedArtifacts = await removeRunArtifacts(api, artifacts, run, pullRequest.number);
+        return Object.freeze({ pullRequestNumber: pullRequest.number, applied: false, removedArtifacts });
+    }
+    if (invariantError) {
+        throw invariantError;
+    }
+    return Object.freeze({
+        pullRequestNumber: pullRequest.number,
+        applied: true,
+        removedArtifacts: comment.removedArtifacts
+    });
+}
+
+async function synchronizeWorkflowRun({ api, repository, run, targets, action }) {
+    const rawRun = requireWorkflowRun(run);
+    if (rawRun.name !== 'PR VSIX Build' || rawRun.event !== 'repository_dispatch') {
+        throw new PrVsixInvariantError('PR VSIX build workflow run: unexpected workflow identity');
+    }
+    const context = parseCiRunName(rawRun.displayTitle);
+    if (!context) {
+        throw new PrVsixInvariantError(`workflow run ${rawRun.id}: missing canonical PR run name`);
+    }
+    if (!CI_ACTIONS.has(context.action)) {
+        return [];
+    }
+    const workflowRun = Object.freeze({ ...rawRun, ...context, source: 'ci' });
+    const pullRequest = await associatedPullRequest(api, rawRun, requireRepository(repository));
+    const artifacts = action === 'completed' ? await api.listRunArtifacts(workflowRun.id) : [];
+    if (!pullRequest) {
+        if (action === 'completed') {
+            await removeRunArtifacts(api, artifacts, workflowRun, workflowRun.pullRequestNumber);
+        }
+        return [];
+    }
+
+    const latest = await latestCiRun(
+        api,
+        workflowRun.workflowId,
+        pullRequest,
+        repository,
+        {
+            createdAfter: workflowRun.createdAt,
+            omitHeadSha: workflowRun.action === 'closed-repair'
+        }
+    );
+    const currentGeneration = latest && latest.id === workflowRun.id &&
+        latest.runAttempt === workflowRun.runAttempt;
+    if (!currentGeneration) {
+        if (action === 'completed') {
+            await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
+        }
+        return [];
+    }
+
+    if (pullRequest.state === 'closed') {
+        const closedRun = Object.freeze({ ...workflowRun, phase: 'closed' });
+        const comment = await upsertComment(
+            api,
+            pullRequest.number,
+            renderClosedComment({ repository, run: closedRun }),
+            closedRun,
+            () => removePreviewArtifacts(api, pullRequest.number)
+        );
+        return [Object.freeze({
+            pullRequestNumber: pullRequest.number,
+            applied: comment.applied,
+            removedArtifacts: comment.removedArtifacts
+        })];
+    }
+    if (pullRequest.state !== 'open') {
+        return [];
+    }
+    if (workflowRun.action === 'closed-repair' ||
+        (workflowRun.action === 'approval-revoked' && automaticBuildAllowed(pullRequest))) {
+        return [];
+    }
+    if (!['in_progress', 'completed'].includes(action)) {
+        throw new PrVsixInvariantError(`PR VSIX build workflow action: unsupported ${action}`);
+    }
+    if (!automaticBuildAllowed(pullRequest)) {
+        const blockedRun = Object.freeze({ ...workflowRun, phase: 'blocked' });
+        const comment = await upsertComment(
+            api,
+            pullRequest.number,
+            renderUnavailableComment({
+                repository,
+                run: blockedRun,
+                reason: EXTERNAL_APPROVAL_REASON
+            }),
+            blockedRun,
+            () => removePreviewArtifacts(api, pullRequest.number)
+        );
+        const removedArtifacts = comment.applied ? comment.removedArtifacts :
+            await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
+        return [Object.freeze({
+            pullRequestNumber: pullRequest.number,
+            applied: comment.applied,
+            removedArtifacts
+        })];
+    }
+    if (workflowRun.action === 'renewal' &&
+        (action === 'in_progress' || action === 'completed' && workflowRun.conclusion !== 'success')) {
+        if (action === 'completed') {
+            await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
+        }
+        return [];
+    }
+    if (action === 'in_progress') {
+        const pendingRun = Object.freeze({ ...workflowRun, phase: 'pending' });
+        const comment = await upsertComment(
+            api,
+            pullRequest.number,
+            renderPendingComment({ repository, run: pendingRun }),
+            pendingRun,
+            () => removePreviewArtifacts(api, pullRequest.number, undefined, workflowRun)
+        );
+        return [Object.freeze({
+            pullRequestNumber: pullRequest.number,
+            applied: comment.applied,
+            removedArtifacts: comment.removedArtifacts
+        })];
+    }
+    const completedRun = Object.freeze({ ...workflowRun, phase: 'completed' });
+    return [await synchronizeCompletedRun({
+        api,
+        repository,
+        run: completedRun,
+        pullRequest,
+        artifacts,
+        targets
+    })];
+}
+
+function isLifecycleArtifact(artifact, workflowRun, marker) {
+    return artifact && !artifact.expired && Number.isSafeInteger(artifact.size_in_bytes) &&
+        artifact.size_in_bytes > 0 && DIGEST_PATTERN.test(String(artifact.digest || '')) &&
+        artifact.workflow_run && artifact.workflow_run.id === workflowRun.id &&
+        marker.runId === workflowRun.id && marker.runAttempt === workflowRun.runAttempt;
+}
+
+async function removeLifecycleMarkers(api, artifacts, workflowRun) {
+    const stale = artifacts.filter((artifact) => {
+        const marker = parseLifecycleArtifactName(artifact.name);
+        return marker && marker.runId === workflowRun.id && marker.runAttempt <= workflowRun.runAttempt;
+    });
+    await Promise.all(stale.map((artifact) => api.deleteArtifact(artifact.id)));
+}
+
+async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRetry }) {
+    const workflowRun = requireWorkflowRun(run);
+    if (workflowRun.name !== 'PR VSIX Event' ||
+        !['pull_request', 'pull_request_target'].includes(workflowRun.event)) {
+        throw new PrVsixInvariantError('lifecycle workflow run: unexpected workflow identity');
+    }
+
+    const artifacts = await api.listRunArtifacts(workflowRun.id);
+    const markers = artifacts.map((artifact) => ({ artifact, marker: parseLifecycleArtifactName(artifact.name) }))
+        .filter(({ artifact, marker }) => marker && isLifecycleArtifact(artifact, workflowRun, marker));
+    if (markers.length === 0) {
+        return [];
+    }
+    if (markers.length !== 1) {
+        throw new PrVsixInvariantError(`lifecycle workflow run ${workflowRun.id}: expected one current marker artifact, found ${markers.length}`);
+    }
+
+    const { marker } = markers[0];
+    let pullRequest = await api.getPullRequest(marker.pullRequestNumber);
+    const expectedState = marker.action === 'closed' ? 'closed' : 'open';
+    const baseRepositoryMatches = pullRequest.base && pullRequest.base.repo &&
+        pullRequest.base.repo.full_name === requireRepository(repository);
+    const sourceMatches = workflowRun.event === 'pull_request_target' || marker.action === 'closed' ||
+        (workflowRun.event === 'pull_request' && workflowRun.pullRequestNumbers.includes(pullRequest.number));
+    const headMatches = pullRequest.head && pullRequest.head.sha === marker.headSha;
+    let current = pullRequest.state === expectedState && baseRepositoryMatches && sourceMatches && headMatches;
+    if (expectedState === 'open') {
+        current = current && pullRequest.base.sha === marker.baseSha;
+    }
+    if (!current) {
+        await removeLifecycleMarkers(api, artifacts, workflowRun);
+        return [];
+    }
+
+    let context = pullRequestContext(pullRequest);
+    let buildable = false;
+    let authorized = true;
+    const ciAction = marker.action === 'edited' ? 'base-edited' : marker.action;
+    if (expectedState === 'open') {
+        authorized = automaticBuildAllowed(pullRequest);
+        if (marker.action === 'unlabeled' && authorized) {
+            await removeLifecycleMarkers(api, artifacts, workflowRun);
+            return [Object.freeze({
+                pullRequestNumber: pullRequest.number,
+                applied: false,
+                removedArtifacts: 0
+            })];
+        }
+        if (authorized) {
+            let stable;
+            try {
+                stable = await waitForStablePullRequest({
+                    api,
+                    pullRequestNumber: pullRequest.number,
+                    expectedHeadSha: marker.headSha,
+                    expectedBaseSha: marker.baseSha,
+                    retry: mergeRetry
+                });
+            } catch (error) {
+                const provisionalRun = Object.freeze({
+                    ...workflowRun,
+                    ...context,
+                    action: ciAction,
+                    source: 'lifecycle',
+                    phase: 'pending'
+                });
+                await upsertComment(
+                    api,
+                    pullRequest.number,
+                    renderPendingComment({ repository, run: provisionalRun }),
+                    provisionalRun,
+                    () => removePreviewArtifacts(api, pullRequest.number)
+                );
+                throw error;
+            }
+            pullRequest = stable.pullRequest;
+            context = stable.context;
+            buildable = stable.buildable;
+        }
+    }
+
+    if (expectedState === 'open' && authorized && buildable) {
+        const currentCi = await latestCiRun(
+            api,
+            'pr-vsix-build.yml',
+            pullRequest,
+            repository,
+            { actions: new Set([ciAction]), createdAfter: workflowRun.createdAt }
+        );
+        if (currentCi) {
+            let result;
+            if (currentCi.status === 'completed') {
+                const ciArtifacts = await api.listRunArtifacts(currentCi.id);
+                result = await synchronizeCompletedRun({
+                    api,
+                    repository,
+                    run: Object.freeze({ ...currentCi, phase: 'completed' }),
+                    pullRequest,
+                    artifacts: ciArtifacts,
+                    targets
+                });
+            } else {
+                const pendingRun = Object.freeze({ ...currentCi, phase: 'pending' });
+                const comment = await upsertComment(
+                    api,
+                    pullRequest.number,
+                    renderPendingComment({ repository, run: pendingRun }),
+                    pendingRun,
+                    () => removePreviewArtifacts(api, pullRequest.number, undefined, currentCi)
+                );
+                result = Object.freeze({
+                    pullRequestNumber: pullRequest.number,
+                    applied: comment.applied,
+                    removedArtifacts: comment.removedArtifacts
+                });
+            }
+            await removeLifecycleMarkers(api, artifacts, workflowRun);
+            return [result];
+        }
+    }
+
+    const phase = expectedState === 'closed' ? 'closed' : !authorized || !buildable ? 'blocked' : 'pending';
+    const lifecycleRun = Object.freeze({
+        ...workflowRun,
+        ...context,
+        action: ciAction,
+        source: 'lifecycle',
+        phase
+    });
+    const body = phase === 'closed' ? renderClosedComment({ repository, run: lifecycleRun }) :
+        !authorized ? renderUnavailableComment({
+            repository,
+            run: lifecycleRun,
+            reason: EXTERNAL_APPROVAL_REASON
+        }) : !buildable ? renderUnavailableComment({
+            repository,
+            run: lifecycleRun,
+            reason: 'The pull request has merge conflicts; CI cannot produce a tested artifact.'
+        }) : renderPendingComment({ repository, run: lifecycleRun });
+    const comment = await upsertComment(
+        api,
+        pullRequest.number,
+        body,
+        lifecycleRun,
+        () => removePreviewArtifacts(api, pullRequest.number)
+    );
+    if (expectedState === 'open' && authorized && buildable) {
+        await api.dispatchRepositoryEvent('refresh-pr-vsix', {
+            pull_request_number: context.pullRequestNumber,
+            head_sha: context.headSha,
+            base_sha: context.baseSha,
+            merge_sha: context.mergeSha,
+            cause: ciAction
+        });
+    }
+    await removeLifecycleMarkers(api, artifacts, workflowRun);
+    return [Object.freeze({
+        pullRequestNumber: pullRequest.number,
+        applied: comment.applied,
+        removedArtifacts: comment.removedArtifacts
+    })];
+}
+
+function resolveWorkflowIdentity(run) {
+    const workflowRun = requireWorkflowRun(run);
+    if (workflowRun.name === 'PR VSIX Build' && workflowRun.event === 'repository_dispatch') {
+        const context = parseCiRunName(workflowRun.displayTitle);
+        if (context) {
+            return Object.freeze({
+                pullRequestNumber: context.pullRequestNumber,
+                processable: CI_ACTIONS.has(context.action)
+            });
+        }
+    }
+    if (workflowRun.name === 'PR VSIX Event' &&
+        ['pull_request', 'pull_request_target'].includes(workflowRun.event)) {
+        const context = parseLifecycleRunName(workflowRun.displayTitle);
+        if (context) {
+            return Object.freeze({ pullRequestNumber: context.pullRequestNumber, processable: true });
+        }
+    }
+    throw new PrVsixInvariantError('workflow run: expected a canonical PR identity');
+}
+
+async function main() {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath) {
+        throw new PrVsixInvariantError('GITHUB_EVENT_PATH: expected a workflow event path');
+    }
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    if (!event.workflow_run) {
+        throw new PrVsixInvariantError('workflow event: expected workflow_run metadata');
+    }
+    if (process.argv[2] === 'resolve') {
+        const identity = resolveWorkflowIdentity(event.workflow_run);
+        process.stdout.write([
+            `pull-request-number=${identity.pullRequestNumber}`,
+            `processable=${identity.processable}`,
+            ''
+        ].join('\n'));
+        return;
+    }
+
+    const repository = requireRepository(event.repository && event.repository.full_name);
+    const targets = JSON.parse(fs.readFileSync(targetsPath, 'utf8'));
+    const api = createGitHubApi({
+        token: process.env.GITHUB_TOKEN,
+        repository,
+        apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
+        retry: apiRetryFromEnvironment()
+    });
+    const mergeRetry = event.workflow_run.name === 'PR VSIX Event' ? requireMergeRetry({
+        attempts: Number(process.env.PR_VSIX_MERGE_ATTEMPTS),
+        intervalMs: Number(process.env.PR_VSIX_MERGE_INTERVAL_MS)
+    }) : undefined;
+    const results = event.workflow_run.name === 'PR VSIX Build' ? await synchronizeWorkflowRun({
+        api,
+        repository,
+        run: event.workflow_run,
+        targets,
+        action: event.action
+    }) : await synchronizeLifecycleRun({
+        api,
+        repository,
+        run: event.workflow_run,
+        targets,
+        mergeRetry
+    });
+    process.stdout.write(`${JSON.stringify({ synchronized: results.length, results })}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+    main().catch((error) => {
+        process.stderr.write(`${error && error.stack ? error.stack : String(error)}\n`);
+        process.exitCode = 1;
+    });
+}
+
+export {
+    BOT_LOGIN,
+    COMMENT_MARKER,
+    PrVsixInvariantError,
+    apiRetryFromEnvironment,
+    automaticBuildAllowed,
+    compareSequence,
+    createGitHubApi,
+    normalizedMergeSha,
+    parseCiRunName,
+    parseCommentMetadata,
+    previewArtifactName,
+    pullRequestContext,
+    renderClosedComment,
+    renderPendingComment,
+    renderReadyComment,
+    renderUnavailableComment,
+    resolveWorkflowIdentity,
+    synchronizeLifecycleRun,
+    synchronizeWorkflowRun,
+    waitForStablePullRequest
+};

--- a/scripts/ci/verify-pr-vsix.mjs
+++ b/scripts/ci/verify-pr-vsix.mjs
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    executableName,
+    platformDirectory,
+    ripgrepTargetPlatforms,
+    uniqueNativePlatforms
+} from '../release/ripgrep-targets.mjs';
+
+const modulePath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(modulePath), '..', '..');
+const targetsPath = path.join(repoRoot, 'scripts', 'release', 'targets.json');
+
+class PrVsixVerificationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'PrVsixVerificationError';
+    }
+}
+
+function expectedRipgrepEntries(targets) {
+    return uniqueNativePlatforms(targets).map((platform) =>
+        `extension/dist/ripgrep/${platformDirectory(platform)}/${executableName(platform)}`
+    ).sort();
+}
+
+function verifyTargetMap(targets) {
+    const configuredTargets = Array.from(ripgrepTargetPlatforms.keys());
+    if (JSON.stringify(configuredTargets) !== JSON.stringify(targets)) {
+        throw new PrVsixVerificationError('ripgrep target map must match targets.json order and membership');
+    }
+}
+
+function verifyEntrySet(entries, targets) {
+    const expected = expectedRipgrepEntries(targets);
+    const actual = entries.filter((entry) => /extension\/dist\/ripgrep\/[^/]+\/rg(?:\.exe)?$/.test(entry)).sort();
+    const unique = Array.from(new Set(actual));
+
+    if (actual.length !== unique.length) {
+        throw new PrVsixVerificationError('PR VSIX contains duplicate ripgrep executable entries');
+    }
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new PrVsixVerificationError(`PR VSIX ripgrep entries mismatch: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+    }
+
+    [
+        'extension/dist/ripgrep/LICENSE',
+        'extension/dist/ripgrep/README.md',
+        'extension/dist/ripgrep/manifest.json'
+    ].forEach((entry) => {
+        if (!entries.includes(entry)) {
+            throw new PrVsixVerificationError(`PR VSIX is missing ${entry}`);
+        }
+    });
+    return expected;
+}
+
+function verifyExecutableModes(zipInfoLines, executableEntries) {
+    executableEntries.filter((entry) => !entry.endsWith('.exe')).forEach((entry) => {
+        const line = zipInfoLines.find((candidate) => candidate.endsWith(` ${entry}`));
+        if (!line || !line.startsWith('-rwx')) {
+            throw new PrVsixVerificationError(`PR VSIX executable mode mismatch: ${entry}`);
+        }
+    });
+}
+
+function runUnzip(args) {
+    const result = spawnSync('unzip', args, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    if (result.status !== 0) {
+        throw new PrVsixVerificationError(`unzip ${args.join(' ')} failed: ${result.stderr.trim()}`);
+    }
+    return result.stdout;
+}
+
+function verifyPrVsix(vsixPath, targets) {
+    const resolvedPath = path.resolve(repoRoot, vsixPath);
+    const stat = fs.statSync(resolvedPath);
+    if (!stat.isFile() || stat.size === 0) {
+        throw new PrVsixVerificationError('PR VSIX must be a non-empty file');
+    }
+
+    verifyTargetMap(targets);
+    runUnzip(['-tqq', resolvedPath]);
+    const entries = runUnzip(['-Z1', resolvedPath]).split(/\r?\n/).filter(Boolean);
+    const nativeEntries = verifyEntrySet(entries, targets);
+    const zipInfoLines = runUnzip(['-Z', '-l', resolvedPath]).split(/\r?\n/).filter(Boolean);
+    verifyExecutableModes(zipInfoLines, nativeEntries);
+    const manifest = runUnzip(['-p', resolvedPath, 'extension.vsixmanifest']);
+    if (/TargetPlatform=/.test(manifest)) {
+        throw new PrVsixVerificationError('PR VSIX must remain untargeted for cross-platform installation');
+    }
+
+    return Object.freeze({
+        path: path.relative(repoRoot, resolvedPath),
+        bytes: stat.size,
+        sha256: createHash('sha256').update(fs.readFileSync(resolvedPath)).digest('hex'),
+        canonicalTargets: targets.length,
+        desktopTargets: targets.filter((target) => target !== 'web').length,
+        nativeBinaries: nativeEntries.length
+    });
+}
+
+function main() {
+    if (process.argv.length !== 3) {
+        throw new PrVsixVerificationError('usage: node scripts/ci/verify-pr-vsix.mjs <path.vsix>');
+    }
+    const targets = JSON.parse(fs.readFileSync(targetsPath, 'utf8'));
+    process.stdout.write(`${JSON.stringify(verifyPrVsix(process.argv[2], targets))}\n`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+    try {
+        main();
+    } catch (error) {
+        process.stderr.write(`${error && error.stack ? error.stack : String(error)}\n`);
+        process.exitCode = 1;
+    }
+}
+
+export {
+    PrVsixVerificationError,
+    expectedRipgrepEntries,
+    verifyEntrySet,
+    verifyExecutableModes,
+    verifyPrVsix,
+    verifyTargetMap
+};

--- a/scripts/release/build-vsix.mjs
+++ b/scripts/release/build-vsix.mjs
@@ -4,6 +4,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { binPathFor } from '@vscode/ripgrep-universal';
+import {
+    executableName as ripgrepExecutableName,
+    platformDirectory as ripgrepPlatformDirectory,
+    ripgrepTargetPlatforms,
+    uniqueNativePlatforms
+} from './ripgrep-targets.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -15,18 +21,7 @@ const targetsPath = path.join(__dirname, 'targets.json');
 const defaultOutputDirectory = path.join(repoRoot, 'artifacts', 'vsix');
 const ripgrepPackageRoot = path.join(repoRoot, 'node_modules', '@vscode', 'ripgrep-universal');
 const ripgrepStageRoot = path.join(repoRoot, 'dist', 'ripgrep');
-const ripgrepTargetPlatforms = new Map([
-    ['win32-x64', Object.freeze({ os: 'win32', arch: 'x64' })],
-    ['win32-arm64', Object.freeze({ os: 'win32', arch: 'arm64' })],
-    ['linux-x64', Object.freeze({ os: 'linux', arch: 'x64' })],
-    ['linux-arm64', Object.freeze({ os: 'linux', arch: 'arm64' })],
-    ['linux-armhf', Object.freeze({ os: 'linux', arch: 'arm' })],
-    ['darwin-x64', Object.freeze({ os: 'darwin', arch: 'x64' })],
-    ['darwin-arm64', Object.freeze({ os: 'darwin', arch: 'arm64' })],
-    ['alpine-x64', Object.freeze({ os: 'linux', arch: 'x64' })],
-    ['alpine-arm64', Object.freeze({ os: 'linux', arch: 'arm64' })],
-    ['web', undefined]
-]);
+const previewTarget = 'pr-preview';
 
 function readJson(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -101,14 +96,6 @@ function cleanSelectedTargetOutputs(directory, packageName, selectedTargets) {
         });
 }
 
-function ripgrepPlatformDirectory(platform) {
-    return `${platform.os}-${platform.arch}`;
-}
-
-function ripgrepExecutableName(platform) {
-    return platform.os === 'win32' ? 'rg.exe' : 'rg';
-}
-
 function resetRipgrepStage() {
     fs.rmSync(ripgrepStageRoot, { recursive: true, force: true });
 }
@@ -124,6 +111,36 @@ function copyRipgrepPackageFile(fileName) {
     fs.copyFileSync(sourcePath, destinationPath);
 }
 
+function copyRipgrepPlatform(platform) {
+    const executableName = ripgrepExecutableName(platform);
+    const platformDirectory = ripgrepPlatformDirectory(platform);
+    const sourcePath = binPathFor(platform);
+    const destinationDirectory = path.join(ripgrepStageRoot, platformDirectory);
+    const destinationPath = path.join(destinationDirectory, executableName);
+
+    if (!fs.existsSync(sourcePath)) {
+        throw new Error(`@vscode/ripgrep-universal does not contain ${platformDirectory}/${executableName}`);
+    }
+
+    fs.mkdirSync(destinationDirectory, { recursive: true });
+    fs.copyFileSync(sourcePath, destinationPath);
+    fs.chmodSync(destinationPath, platform.os === 'win32' ? 0o644 : 0o755);
+
+    return Object.freeze({
+        platform: platformDirectory,
+        executable: executableName
+    });
+}
+
+function writeRipgrepManifest(manifest) {
+    fs.writeFileSync(path.join(ripgrepStageRoot, 'manifest.json'), JSON.stringify(manifest, null, 4) + '\n');
+}
+
+function copyRipgrepMetadata() {
+    copyRipgrepPackageFile('LICENSE');
+    copyRipgrepPackageFile('README.md');
+}
+
 function stageRipgrepForTarget(target) {
     const platform = ripgrepTargetPlatforms.get(target);
 
@@ -137,39 +154,44 @@ function stageRipgrepForTarget(target) {
         return;
     }
 
-    const executableName = ripgrepExecutableName(platform);
-    const platformDirectory = ripgrepPlatformDirectory(platform);
-    const sourcePath = binPathFor(platform);
-    const destinationDirectory = path.join(ripgrepStageRoot, platformDirectory);
-    const destinationPath = path.join(destinationDirectory, executableName);
     const packageJson = readJson(path.join(ripgrepPackageRoot, 'package.json'));
-
-    if (!fs.existsSync(sourcePath)) {
-        throw new Error(`@vscode/ripgrep-universal does not contain ${platformDirectory}/${executableName}`);
-    }
-
-    fs.mkdirSync(destinationDirectory, { recursive: true });
-    fs.copyFileSync(sourcePath, destinationPath);
-    fs.chmodSync(destinationPath, platform.os === 'win32' ? 0o644 : 0o755);
-    copyRipgrepPackageFile('LICENSE');
-    copyRipgrepPackageFile('README.md');
-    fs.writeFileSync(path.join(ripgrepStageRoot, 'manifest.json'), JSON.stringify({
+    const stagedPlatform = copyRipgrepPlatform(platform);
+    copyRipgrepMetadata();
+    writeRipgrepManifest({
         package: '@vscode/ripgrep-universal',
         version: packageJson.version,
         target: target,
-        platform: platformDirectory,
-        executable: executableName
-    }, null, 4) + '\n');
+        platform: stagedPlatform.platform,
+        executable: stagedPlatform.executable
+    });
+}
+
+function stageRipgrepForPreview(targets) {
+    const packageJson = readJson(path.join(ripgrepPackageRoot, 'package.json'));
+
+    resetRipgrepStage();
+    const platforms = uniqueNativePlatforms(targets).map(copyRipgrepPlatform);
+    copyRipgrepMetadata();
+    writeRipgrepManifest({
+        package: '@vscode/ripgrep-universal',
+        version: packageJson.version,
+        target: previewTarget,
+        platforms: platforms
+    });
 }
 
 async function packageTarget(target, outputPath) {
-    await pack({
+    const options = {
         cwd: repoRoot,
         packagePath: outputPath,
-        target: target,
         dependencies: false,
         useYarn: false
-    });
+    };
+    if (target !== undefined) {
+        options.target = target;
+    }
+
+    await pack(options);
 
     process.stdout.write(`${outputPath}\n`);
 }
@@ -178,20 +200,40 @@ async function main() {
     const packageJson = readJson(packageJsonPath);
     const supportedTargets = readJson(targetsPath);
     const outputDirectory = process.env.VSIX_OUTDIR ? path.resolve(repoRoot, process.env.VSIX_OUTDIR) : defaultOutputDirectory;
-    const selectedTargets = normalizeRequestedTargets(process.argv.slice(2), supportedTargets);
+    const requested = process.argv.slice(2).flatMap((value) => value.split(','))
+        .map((value) => value.trim().replace(/^--/, ''))
+        .filter(Boolean);
+    const previewRequested = requested.includes(previewTarget);
+    if (previewRequested && (requested.length !== 1 || requested[0] !== previewTarget)) {
+        throw new Error(`${previewTarget} cannot be combined with release targets.`);
+    }
+    const selectedTargets = previewRequested ? supportedTargets : normalizeRequestedTargets(requested, supportedTargets);
 
     ensureOutputDirectory(outputDirectory);
-    cleanSelectedTargetOutputs(outputDirectory, packageJson.name, selectedTargets);
+    if (!previewRequested) {
+        cleanSelectedTargetOutputs(outputDirectory, packageJson.name, selectedTargets);
+    }
 
     try {
         if (process.env.SKIP_PREPUBLISH !== '1') {
             run('npm', ['run', 'vscode:prepublish']);
         }
 
-        for (const target of selectedTargets) {
-            stageRipgrepForTarget(target);
-            const outputPath = path.join(outputDirectory, `${packageJson.name}-${packageJson.version}-${target}.vsix`);
-            await packageTarget(target, outputPath);
+        if (previewRequested) {
+            const fileName = process.env.PR_VSIX_FILENAME || `${packageJson.name}-${packageJson.version}-${previewTarget}.vsix`;
+            if (path.basename(fileName) !== fileName || !/^[A-Za-z0-9._-]+\.vsix$/.test(fileName)) {
+                throw new Error('PR_VSIX_FILENAME must be a portable VSIX basename.');
+            }
+            const outputPath = path.join(outputDirectory, fileName);
+            fs.rmSync(outputPath, { force: true });
+            stageRipgrepForPreview(selectedTargets);
+            await packageTarget(undefined, outputPath);
+        } else {
+            for (const target of selectedTargets) {
+                stageRipgrepForTarget(target);
+                const outputPath = path.join(outputDirectory, `${packageJson.name}-${packageJson.version}-${target}.vsix`);
+                await packageTarget(target, outputPath);
+            }
         }
     } finally {
         resetRipgrepStage();

--- a/scripts/release/ripgrep-targets.mjs
+++ b/scripts/release/ripgrep-targets.mjs
@@ -1,0 +1,43 @@
+const ripgrepTargetPlatforms = new Map([
+    ['win32-x64', Object.freeze({ os: 'win32', arch: 'x64' })],
+    ['win32-arm64', Object.freeze({ os: 'win32', arch: 'arm64' })],
+    ['linux-x64', Object.freeze({ os: 'linux', arch: 'x64' })],
+    ['linux-arm64', Object.freeze({ os: 'linux', arch: 'arm64' })],
+    ['linux-armhf', Object.freeze({ os: 'linux', arch: 'arm' })],
+    ['darwin-x64', Object.freeze({ os: 'darwin', arch: 'x64' })],
+    ['darwin-arm64', Object.freeze({ os: 'darwin', arch: 'arm64' })],
+    ['alpine-x64', Object.freeze({ os: 'linux', arch: 'x64' })],
+    ['alpine-arm64', Object.freeze({ os: 'linux', arch: 'arm64' })],
+    ['web', undefined]
+]);
+
+function platformDirectory(platform) {
+    return `${platform.os}-${platform.arch}`;
+}
+
+function executableName(platform) {
+    return platform.os === 'win32' ? 'rg.exe' : 'rg';
+}
+
+function uniqueNativePlatforms(targets) {
+    const byDirectory = new Map();
+
+    targets.forEach((target) => {
+        if (!ripgrepTargetPlatforms.has(target)) {
+            throw new Error(`Unsupported ripgrep target "${target}".`);
+        }
+
+        const platform = ripgrepTargetPlatforms.get(target);
+        if (platform !== undefined) {
+            byDirectory.set(platformDirectory(platform), platform);
+        }
+    });
+    return Array.from(byDirectory.values());
+}
+
+export {
+    executableName,
+    platformDirectory,
+    ripgrepTargetPlatforms,
+    uniqueNativePlatforms
+};

--- a/test/pr-vsix-comment.test.js
+++ b/test/pr-vsix-comment.test.js
@@ -1,0 +1,1202 @@
+var path = require( 'path' );
+var pathToFileURL = require( 'url' ).pathToFileURL;
+
+var modulePromise = import( pathToFileURL(
+    path.join( __dirname, '..', 'scripts', 'ci', 'sync-pr-vsix-comment.mjs' )
+).href );
+
+var REPOSITORY = 'FanaticPythoner/better-todo-tree';
+var SHA_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+var SHA_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+var SHA_C = 'cccccccccccccccccccccccccccccccccccccccc';
+var SHA_D = 'dddddddddddddddddddddddddddddddddddddddd';
+var TARGETS = require( '../scripts/release/targets.json' );
+
+function ciTitle( overrides )
+{
+    var values = Object.assign( {
+        number: 19,
+        head: SHA_A,
+        base: SHA_B,
+        merge: SHA_C,
+        action: 'synchronize'
+    }, overrides || {} );
+    return 'PR VSIX Build PR #' + values.number + ' head ' + values.head + ' base ' + values.base +
+        ' merge ' + values.merge + ' action ' + values.action;
+}
+
+function workflowRun( overrides )
+{
+    return Object.assign( {
+        id: 200,
+        run_attempt: 1,
+        run_number: 20,
+        workflow_id: 10,
+        event: 'repository_dispatch',
+        name: 'PR VSIX Build',
+        status: 'completed',
+        head_sha: SHA_B,
+        head_branch: 'master',
+        head_repository: { id: 1 },
+        created_at: '2026-07-11T10:00:00Z',
+        run_started_at: '2026-07-11T10:00:00Z',
+        updated_at: '2026-07-11T10:06:00Z',
+        display_title: ciTitle(),
+        conclusion: 'success',
+        pull_requests: []
+    }, overrides || {} );
+}
+
+function pullRequest( overrides )
+{
+    return Object.assign( {
+        number: 19,
+        state: 'open',
+        created_at: '2026-07-11T09:00:00Z',
+        closed_at: null,
+        mergeable: true,
+        mergeable_state: 'clean',
+        merge_commit_sha: SHA_C,
+        author_association: 'OWNER',
+        labels: [],
+        head: { sha: SHA_A, ref: 'fix/issue-19', repo: { id: 99 } },
+        base: {
+            sha: SHA_B,
+            ref: 'master',
+            repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+        }
+    }, overrides || {} );
+}
+
+function artifact( overrides )
+{
+    return Object.assign( {
+        id: 300,
+        name: 'better-todo-tree-pr-19.vsix',
+        expired: false,
+        size_in_bytes: 15000000,
+        digest: 'sha256:' + 'e'.repeat( 64 ),
+        created_at: '2026-07-11T10:05:00Z',
+        expires_at: '2026-10-09T10:05:00Z',
+        workflow_run: { id: 200, head_sha: SHA_B }
+    }, overrides || {} );
+}
+
+function lifecycleRun( overrides )
+{
+    return Object.assign( {
+        id: 500,
+        run_attempt: 1,
+        run_number: 50,
+        workflow_id: 11,
+        event: 'pull_request_target',
+        name: 'PR VSIX Event',
+        status: 'completed',
+        head_sha: SHA_B,
+        head_branch: 'master',
+        head_repository: { id: 1 },
+        created_at: '2026-07-11T10:00:01Z',
+        run_started_at: '2026-07-11T10:00:01Z',
+        updated_at: '2026-07-11T10:00:03Z',
+        display_title: 'PR VSIX Event #19 synchronize',
+        conclusion: 'success',
+        pull_requests: []
+    }, overrides || {} );
+}
+
+function lifecycleArtifact( action, overrides )
+{
+    return Object.assign( {
+        id: 600,
+        name: 'better-todo-tree-pr-vsix-event-19-head-' + SHA_A + '-base-' + SHA_B +
+            '-merge-' + SHA_C + '-' + action + '-run-500-attempt-1',
+        expired: false,
+        size_in_bytes: 100,
+        digest: 'sha256:' + 'f'.repeat( 64 ),
+        created_at: '2026-07-11T10:00:02Z',
+        expires_at: '2026-07-12T10:00:02Z',
+        workflow_run: { id: 500, head_sha: SHA_B }
+    }, overrides || {} );
+}
+
+function apiFixture( options )
+{
+    var settings = options || {};
+    var activeRun = workflowRun();
+    var calls = {
+        createdComments: [],
+        updatedComments: [],
+        deletedComments: [],
+        deletedArtifacts: [],
+        dispatchedEvents: [],
+        workflowQueries: [],
+        order: []
+    };
+    var api = {
+        getPullRequest: async function( number )
+        {
+            return ( settings.pullRequests || [ pullRequest() ] ).find( function( item )
+            {
+                return item.number === number;
+            } );
+        },
+        getCommit: async function()
+        {
+            return settings.mergeCommit || { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        },
+        listRunArtifacts: async function( runId )
+        {
+            if( settings.runArtifactsByRun )
+            {
+                return settings.runArtifactsByRun[ runId ] || [];
+            }
+            return settings.runArtifacts || [];
+        },
+        listWorkflowRuns: async function( workflow, filters )
+        {
+            calls.workflowQueries.push( { workflow: workflow, filters: filters } );
+            return ( settings.workflowRuns || [ activeRun ] ).filter( function( item )
+            {
+                return ( !filters || !filters.createdAfter ||
+                    Date.parse( item.created_at ) >= Date.parse( filters.createdAfter ) ) &&
+                    ( !filters || !filters.headSha || item.head_sha === filters.headSha );
+            } );
+        },
+        listArtifactsByName: async function( name )
+        {
+            return ( settings.repositoryArtifacts || [] ).filter( function( item )
+            {
+                return item.name === name;
+            } );
+        },
+        deleteArtifact: async function( id )
+        {
+            calls.deletedArtifacts.push( id );
+            calls.order.push( 'delete-artifact-' + id );
+            if( settings.deleteArtifactError )
+            {
+                throw settings.deleteArtifactError;
+            }
+        },
+        listIssueComments: async function()
+        {
+            return settings.comments || [];
+        },
+        createIssueComment: async function( number, body )
+        {
+            calls.createdComments.push( { number: number, body: body } );
+            calls.order.push( 'create-comment' );
+            return { id: 400 };
+        },
+        updateIssueComment: async function( id, body )
+        {
+            calls.updatedComments.push( { id: id, body: body } );
+            calls.order.push( 'update-comment-' + id );
+            return { id: id };
+        },
+        deleteIssueComment: async function( id )
+        {
+            calls.deletedComments.push( id );
+        },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            calls.dispatchedEvents.push( { name: name, payload: payload } );
+        }
+    };
+    return {
+        api: api,
+        calls: calls,
+        settings: settings,
+        setActiveRun: function( run ) { activeRun = run; }
+    };
+}
+
+function synchronize( module, fixture, run, action )
+{
+    fixture.setActiveRun( run );
+    return module.synchronizeWorkflowRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: run,
+        targets: TARGETS,
+        action: action || 'completed'
+    } );
+}
+
+function synchronizeLifecycle( module, fixture, run )
+{
+    return module.synchronizeLifecycleRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: run,
+        targets: TARGETS,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+}
+
+function commentRun( module, run, phase )
+{
+    var context = module.parseCiRunName( run.display_title );
+    return Object.assign( {
+        id: run.id,
+        runAttempt: run.run_attempt,
+        runNumber: run.run_number,
+        workflowHeadSha: run.head_sha,
+        startedAt: run.run_started_at,
+        updatedAt: run.updated_at,
+        status: run.status,
+        conclusion: run.conclusion,
+        source: 'ci',
+        phase: phase || 'completed'
+    }, context );
+}
+
+function renderedReadyComment( module, run, item )
+{
+    return module.renderReadyComment( {
+        repository: REPOSITORY,
+        run: commentRun( module, run ),
+        artifact: item,
+        targets: TARGETS
+    } );
+}
+
+QUnit.module( 'PR VSIX comment synchronization' );
+
+QUnit.test( 'successful current run publishes one raw VSIX link and removes duplicate namespace artifacts', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var fixture = apiFixture( {
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, prior ]
+    } );
+    var results = await synchronize( module, fixture, workflowRun() );
+    var body = fixture.calls.updatedComments[ 0 ].body;
+
+    assert.deepEqual( results, [ { pullRequestNumber: 19, applied: true, removedArtifacts: 1 } ] );
+    assert.ok( body.indexOf( 'actions/runs/200/artifacts/300' ) !== -1 );
+    assert.ok( body.indexOf( '`win32-x64`' ) !== -1 );
+    assert.ok( body.indexOf( '`web`' ) === -1 );
+    assert.ok( body.indexOf( 'unreviewed code from this pull request' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+} );
+
+QUnit.test( 'linkless state is published before stale artifact cleanup', async function( assert )
+{
+    var module = await modulePromise;
+    var priorRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z',
+        display_title: ciTitle( { head: SHA_D } )
+    } );
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var failedRun = workflowRun( { id: 201, run_number: 21, conclusion: 'failure' } );
+    var fixture = apiFixture( {
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, priorRun, prior ),
+            user: { login: 'github-actions[bot]' }
+        } ],
+        repositoryArtifacts: [ prior ]
+    } );
+
+    await synchronize( module, fixture, failedRun );
+
+    assert.deepEqual( fixture.calls.order, [ 'update-comment-401', 'delete-artifact-299' ] );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+} );
+
+QUnit.test( 'cleanup failure leaves a linkless recoverable transition', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var oldArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var current = artifact();
+    var fixture = apiFixture( {
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, oldArtifact ],
+        deleteArtifactError: new Error( 'delete failed' ),
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, oldRun, oldArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error.message === 'delete failed';
+    } );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: preparing' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.order, [ 'update-comment-401', 'delete-artifact-299' ] );
+} );
+
+QUnit.test( 'stale head completion deletes only its run artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } },
+            merge_commit_sha: SHA_D
+        } ) ],
+        runArtifacts: [ artifact() ],
+        repositoryArtifacts: [ artifact() ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, workflowRun() ), [] );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'successful rerun rejects an artifact created before the current attempt', async function( assert )
+{
+    var module = await modulePromise;
+    var rerun = workflowRun( {
+        run_attempt: 2,
+        run_started_at: '2026-07-11T11:00:00Z',
+        updated_at: '2026-07-11T11:06:00Z'
+    } );
+    var staleAttempt = artifact( { created_at: '2026-07-11T10:05:00Z' } );
+    var fixture = apiFixture( {
+        workflowRuns: [ rerun ],
+        runArtifacts: [ staleAttempt ],
+        repositoryArtifacts: [ staleAttempt ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, rerun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message.indexOf( 'better-todo-tree-pr-19.vsix artifact, found 0' ) !== -1;
+    } );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'noncanonical build run name fails closed', async function( assert )
+{
+    var module = await modulePromise;
+    var fixture = apiFixture();
+    var run = workflowRun( { display_title: 'PR VSIX Build' } );
+
+    await assert.rejects( synchronize( module, fixture, run ), function( error )
+    {
+        return error.message.indexOf( 'missing canonical PR run name' ) !== -1;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+} );
+
+QUnit.test( 'non-dispatch build workflow identity fails closed', async function( assert )
+{
+    var module = await modulePromise;
+    var fixture = apiFixture();
+
+    await assert.rejects( synchronize( module, fixture, workflowRun( { event: 'pull_request' } ) ), function( error )
+    {
+        return error.message.indexOf( 'unexpected workflow identity' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'new same-context CI generation replaces completed state immediately', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var oldArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var currentRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        status: 'in_progress',
+        conclusion: null,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:10:00Z'
+    } );
+    var fixture = apiFixture( {
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, oldRun, oldArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ],
+        repositoryArtifacts: [ oldArtifact ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, currentRun, 'in_progress' ), [
+        { pullRequestNumber: 19, applied: true, removedArtifacts: 1 }
+    ] );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+} );
+
+QUnit.test( 'completed state blocks a delayed pending callback from the same generation', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun( { status: 'in_progress', conclusion: null } );
+    var current = artifact();
+    var fixture = apiFixture( {
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, run, 'in_progress' ), [
+        { pullRequestNumber: 19, applied: false, removedArtifacts: 0 }
+    ] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'completed cleanup preserves an artifact from a concurrently newer generation', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var newer = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:07:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var fixture = apiFixture( {
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, newer ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, workflowRun() ) )[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'completed cleanup preserves a newer rerun artifact with the same run id', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var newerAttempt = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:07:00Z'
+    } );
+    var fixture = apiFixture( {
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, newerAttempt ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, workflowRun() ) )[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'superseded rerun attempt deletes its exact attempt artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun();
+    var latestRun = workflowRun( {
+        run_attempt: 2,
+        run_started_at: '2026-07-11T11:00:00Z',
+        updated_at: '2026-07-11T11:06:00Z'
+    } );
+    var oldArtifact = artifact();
+    var fixture = apiFixture( {
+        workflowRuns: [ latestRun ],
+        runArtifacts: [ oldArtifact ],
+        repositoryArtifacts: [ oldArtifact ]
+    } );
+
+    assert.deepEqual( await module.synchronizeWorkflowRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: oldRun,
+        targets: TARGETS,
+        action: 'completed'
+    } ), [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'superseded attempt callback cannot delete the newer attempt artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun();
+    var latestRun = workflowRun( {
+        run_attempt: 2,
+        run_started_at: '2026-07-11T11:00:00Z',
+        updated_at: '2026-07-11T11:06:00Z'
+    } );
+    var latestArtifact = artifact( { created_at: '2026-07-11T11:05:00Z' } );
+    var fixture = apiFixture( {
+        workflowRuns: [ latestRun ],
+        runArtifacts: [ latestArtifact ],
+        repositoryArtifacts: [ latestArtifact ]
+    } );
+
+    assert.deepEqual( await module.synchronizeWorkflowRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: oldRun,
+        targets: TARGETS,
+        action: 'completed'
+    } ), [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'superseded same-SHA workflow generation deletes its artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun();
+    var latestRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        status: 'in_progress',
+        conclusion: null,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:10:00Z'
+    } );
+    var fixture = apiFixture( {
+        workflowRuns: [ latestRun, oldRun ],
+        runArtifacts: [ artifact() ]
+    } );
+
+    assert.deepEqual( await module.synchronizeWorkflowRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: oldRun,
+        targets: TARGETS,
+        action: 'completed'
+    } ), [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'repository dispatch run validates immutable PR context', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun( {
+        event: 'repository_dispatch',
+        head_sha: SHA_B,
+        head_branch: 'master',
+        head_repository: { id: 1 },
+        display_title: ciTitle( { action: 'repair' } )
+    } );
+    var current = artifact( { workflow_run: { id: 200, head_sha: SHA_B } } );
+    var fixture = apiFixture( { runArtifacts: [ current ], repositoryArtifacts: [ current ] } );
+
+    assert.equal( ( await synchronize( module, fixture, run ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: ready' ) !== -1 );
+} );
+
+QUnit.test( 'metadata-only CI edit is ignored without artifact mutation', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun( { display_title: ciTitle( { action: 'edited' } ), conclusion: 'skipped' } );
+    var fixture = apiFixture( { repositoryArtifacts: [ artifact() ] } );
+
+    assert.deepEqual( await synchronize( module, fixture, run ), [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'renewal preserves the valid artifact through pending and failed builds', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var run = workflowRun( {
+        display_title: ciTitle( { action: 'renewal' } ),
+        status: 'in_progress',
+        conclusion: null
+    } );
+    var fixture = apiFixture( {
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, run, 'in_progress' ), [] );
+    run.status = 'completed';
+    run.conclusion = 'failure';
+    fixture.setActiveRun( run );
+    assert.deepEqual( await module.synchronizeWorkflowRun( {
+        api: fixture.api,
+        repository: REPOSITORY,
+        run: run,
+        targets: TARGETS,
+        action: 'completed'
+    } ), [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'publisher revokes a fork artifact when approval changes during the build', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            author_association: 'NONE',
+            head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+        } ) ],
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, workflowRun( {
+        display_title: ciTitle( { action: 'labeled' } )
+    } ) ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'safe-to-test' ) !== -1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'stale cleanup completion preserves state after authorization reversal', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var cleanupRun = workflowRun( {
+        display_title: ciTitle( { action: 'approval-revoked' } ),
+        conclusion: 'failure'
+    } );
+    var fixture = apiFixture( {
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, cleanupRun ), [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'base-push conflict invalidates the previous merge artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var old = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var run = workflowRun( {
+        id: 202,
+        run_number: 22,
+        status: 'in_progress',
+        conclusion: null,
+        display_title: ciTitle( { merge: 'none', action: 'base-push' } )
+    } );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            mergeable: false,
+            mergeable_state: 'dirty',
+            merge_commit_sha: null
+        } ) ],
+        repositoryArtifacts: [ old ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, oldRun, old ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, run, 'in_progress' ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+} );
+
+QUnit.test( 'trusted lifecycle marker posts building state and removes the prior slot', async function( assert )
+{
+    var module = await modulePromise;
+    var marker = lifecycleArtifact( 'synchronize' );
+    var prior = artifact( { id: 299, workflow_run: { id: 199, head_sha: SHA_B } } );
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ marker ],
+        repositoryArtifacts: [ prior ]
+    } );
+
+    assert.deepEqual( await synchronizeLifecycle( module, fixture, lifecycleRun() ), [
+        { pullRequestNumber: 19, applied: true, removedArtifacts: 1 }
+    ] );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 600 ] );
+} );
+
+QUnit.test( 'pull-request fallback requires server-associated PR identity', async function( assert )
+{
+    var module = await modulePromise;
+    var marker = lifecycleArtifact( 'synchronize' );
+    var acceptedFixture = apiFixture( { workflowRuns: [], runArtifacts: [ marker ] } );
+    var rejectedFixture = apiFixture( { workflowRuns: [], runArtifacts: [ marker ] } );
+
+    assert.equal( ( await synchronizeLifecycle( module, acceptedFixture, lifecycleRun( {
+        event: 'pull_request',
+        pull_requests: [ { number: 19 } ]
+    } ) ) )[ 0 ].applied, true );
+    assert.deepEqual( await synchronizeLifecycle( module, rejectedFixture, lifecycleRun( {
+        event: 'pull_request',
+        pull_requests: []
+    } ) ), [] );
+    assert.deepEqual( rejectedFixture.calls.deletedArtifacts, [ 600 ] );
+} );
+
+QUnit.test( 'same-event lifecycle completion cannot replace successful CI state', async function( assert )
+{
+    var module = await modulePromise;
+    var markerRun = lifecycleRun();
+    var marker = lifecycleArtifact( 'synchronize' );
+    var currentRun = workflowRun( {
+        created_at: '2026-07-11T10:00:02Z',
+        run_started_at: '2026-07-11T10:00:02Z'
+    } );
+    var current = artifact();
+    var fixture = apiFixture( {
+        workflowRuns: [ currentRun ],
+        runArtifactsByRun: { 500: [ marker ], 200: [ current ] },
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, currentRun, current ),
+            user: { login: 'github-actions[bot]' }
+        } ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    assert.deepEqual( await synchronizeLifecycle( module, fixture, markerRun ), [
+        { pullRequestNumber: 19, applied: true, removedArtifacts: 0 }
+    ] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600 ] );
+} );
+
+QUnit.test( 'successful same-event build overrides a later-started lifecycle state', async function( assert )
+{
+    var module = await modulePromise;
+    var lifecycleState = {
+        id: 500,
+        runAttempt: 1,
+        runNumber: 50,
+        startedAt: '2026-07-11T10:01:00Z',
+        headSha: SHA_A,
+        baseSha: SHA_B,
+        mergeSha: SHA_C,
+        action: 'synchronize',
+        source: 'lifecycle',
+        phase: 'pending'
+    };
+    var provisionalBody = module.renderPendingComment( {
+        repository: REPOSITORY,
+        run: lifecycleState
+    } );
+    var currentRun = workflowRun();
+    var current = artifact( { created_at: '2026-07-11T10:05:00Z' } );
+    var fixture = apiFixture( {
+        workflowRuns: [ currentRun ],
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ],
+        comments: [ { id: 401, body: provisionalBody, user: { login: 'github-actions[bot]' } } ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, currentRun ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ fixture.calls.updatedComments.length - 1 ].body.indexOf( 'PR VSIX: ready' ) !== -1 );
+} );
+
+QUnit.test( 'newer merge-conflict lifecycle state invalidates an older ready artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z'
+    } );
+    var oldArtifact = artifact( { id: 299, workflow_run: { id: 199, head_sha: SHA_B } } );
+    var marker = lifecycleArtifact( 'synchronize' );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( { mergeable: false, mergeable_state: 'dirty' } ) ],
+        workflowRuns: [ oldRun ],
+        runArtifacts: [ marker ],
+        repositoryArtifacts: [ oldArtifact ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, oldRun, oldArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.equal( ( await synchronizeLifecycle( module, fixture, lifecycleRun() ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'merge conflicts' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 600 ] );
+} );
+
+QUnit.test( 'safe-to-test removal revokes external preview access without rebuilding', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var marker = lifecycleArtifact( 'unlabeled' );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            author_association: 'NONE',
+            head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+        } ) ],
+        runArtifacts: [ marker ],
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.equal( ( await synchronizeLifecycle( module, fixture, lifecycleRun( {
+        display_title: 'PR VSIX Event #19 unlabeled'
+    } ) ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'safe-to-test' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300, 600 ] );
+    assert.deepEqual( fixture.calls.dispatchedEvents, [] );
+} );
+
+QUnit.test( 'safe-to-test removal preserves previews with intrinsic authorization', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var marker = lifecycleArtifact( 'unlabeled' );
+    var fixture = apiFixture( {
+        runArtifacts: [ marker ],
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.deepEqual( await synchronizeLifecycle( module, fixture, lifecycleRun( {
+        display_title: 'PR VSIX Event #19 unlabeled'
+    } ) ), [ { pullRequestNumber: 19, applied: false, removedArtifacts: 0 } ] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600 ] );
+    assert.deepEqual( fixture.calls.dispatchedEvents, [] );
+} );
+
+QUnit.test( 'safe-to-test reapproval dispatches a build instead of reusing deleted history', async function( assert )
+{
+    var module = await modulePromise;
+    var historicalRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        display_title: ciTitle( { action: 'labeled' } ),
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var marker = lifecycleArtifact( 'labeled' );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            author_association: 'NONE',
+            labels: [ { name: 'safe-to-test' } ],
+            head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+        } ) ],
+        workflowRuns: [ historicalRun ],
+        runArtifacts: [ marker ]
+    } );
+
+    assert.equal( ( await synchronizeLifecycle( module, fixture, lifecycleRun( {
+        display_title: 'PR VSIX Event #19 labeled'
+    } ) ) )[ 0 ].applied, true );
+    assert.equal( fixture.calls.dispatchedEvents.length, 1 );
+    assert.equal( fixture.calls.dispatchedEvents[ 0 ].payload.cause, 'labeled' );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600 ] );
+} );
+
+QUnit.test( 'closed lifecycle marker ignores later base movement and removes the retained artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var marker = lifecycleArtifact( 'closed' );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            state: 'closed',
+            closed_at: '2026-07-11T10:01:00Z',
+            merge_commit_sha: SHA_D,
+            base: {
+                sha: SHA_D,
+                ref: 'master',
+                repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+            }
+        } ) ],
+        runArtifacts: [ marker ],
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.equal( ( await synchronizeLifecycle( module, fixture, lifecycleRun( {
+        display_title: 'PR VSIX Event #19 closed'
+    } ) ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'was removed when the pull request closed' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300, 600 ] );
+} );
+
+QUnit.test( 'scheduled closed repair removes an artifact after the close timestamp', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var repairRun = workflowRun( {
+        id: 205,
+        run_number: 25,
+        head_sha: SHA_D,
+        display_title: ciTitle( { action: 'closed-repair' } ),
+        created_at: '2026-07-11T11:00:00Z',
+        run_started_at: '2026-07-11T11:00:00Z',
+        updated_at: '2026-07-11T11:00:03Z'
+    } );
+    var fixture = apiFixture( {
+        pullRequests: [ pullRequest( {
+            state: 'closed',
+            closed_at: '2026-07-11T10:10:00Z',
+            merge_commit_sha: SHA_D,
+            base: {
+                sha: SHA_D,
+                ref: 'master',
+                repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+            }
+        } ) ],
+        workflowRuns: [ repairRun ],
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, repairRun ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'was removed when the pull request closed' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'lifecycle rerun selects its exact attempt marker and removes stale attempts', async function( assert )
+{
+    var module = await modulePromise;
+    var attemptOne = lifecycleArtifact( 'synchronize' );
+    var attemptTwo = lifecycleArtifact( 'synchronize', {
+        id: 601,
+        name: lifecycleArtifact( 'synchronize' ).name.replace( 'attempt-1', 'attempt-2' )
+    } );
+    var run = lifecycleRun( {
+        run_attempt: 2,
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:10:03Z'
+    } );
+    var fixture = apiFixture( { workflowRuns: [], runArtifacts: [ attemptOne, attemptTwo ] } );
+
+    assert.equal( ( await synchronizeLifecycle( module, fixture, run ) )[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600, 601 ] );
+} );
+
+QUnit.test( 'workflow identity resolver covers CI and lifecycle events', async function( assert )
+{
+    var module = await modulePromise;
+
+    assert.deepEqual( module.resolveWorkflowIdentity( workflowRun() ), {
+        pullRequestNumber: 19,
+        processable: true
+    } );
+    assert.deepEqual( module.resolveWorkflowIdentity( workflowRun( {
+        display_title: ciTitle( { action: 'edited' } )
+    } ) ), {
+        pullRequestNumber: 19,
+        processable: false
+    } );
+    assert.deepEqual( module.resolveWorkflowIdentity( lifecycleRun() ), {
+        pullRequestNumber: 19,
+        processable: true
+    } );
+} );
+
+QUnit.test( 'GitHub API adapter paginates and dispatches refresh events', async function( assert )
+{
+    var module = await modulePromise;
+    var requests = [];
+    var pageValues = Array.from( { length: 100 }, function( _, index )
+    {
+        return { id: index + 1 };
+    } );
+    var api = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        fetchImpl: async function( url, options )
+        {
+            var requestUrl = new URL( url );
+            var page = requestUrl.searchParams.get( 'page' );
+            requests.push( { url: url, options: options } );
+            if( options.method === 'POST' )
+            {
+                return new Response( null, { status: 204 } );
+            }
+            return new Response( JSON.stringify( {
+                artifacts: page === '1' ? pageValues : [ { id: 101 } ]
+            } ) );
+        }
+    } );
+
+    assert.equal( ( await api.listArtifactsByName( 'better-todo-tree-pr-19.vsix' ) ).length, 101 );
+    await api.dispatchRepositoryEvent( 'refresh-pr-vsix', { pull_request_number: 19 } );
+    assert.equal( requests.length, 3 );
+    assert.equal( requests[ 0 ].options.headers.Authorization, 'Bearer token' );
+    assert.equal( requests[ 0 ].options.headers[ 'X-GitHub-Api-Version' ], '2026-03-10' );
+    assert.equal( JSON.parse( requests[ 2 ].options.body ).event_type, 'refresh-pr-vsix' );
+} );
+
+QUnit.test( 'GitHub API adapter exposes transport and response contract failures', async function( assert )
+{
+    var module = await modulePromise;
+    var transportApi = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        fetchImpl: async function()
+        {
+            throw new Error( 'network failure' );
+        }
+    } );
+    var jsonApi = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        fetchImpl: async function()
+        {
+            return new Response( '<html>', { status: 502 } );
+        }
+    } );
+
+    await assert.rejects( transportApi.getPullRequest( 19 ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError && error.cause.message === 'network failure';
+    } );
+    await assert.rejects( jsonApi.getPullRequest( 19 ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message.indexOf( 'HTTP 502: <html>' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'GitHub API adapter exposes batched repository artifact and comment scans', async function( assert )
+{
+    var module = await modulePromise;
+    var requests = [];
+    var api = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        fetchImpl: async function( url )
+        {
+            requests.push( url );
+            return new Response( url.indexOf( '/issues/comments?' ) === -1 ?
+                JSON.stringify( { artifacts: [] } ) : JSON.stringify( [] ), { status: 200 } );
+        }
+    } );
+
+    assert.deepEqual( await api.listRepositoryArtifacts(), [] );
+    assert.deepEqual(
+        await api.listRepositoryIssueComments( '2026-04-11T12:00:00Z' ),
+        []
+    );
+    assert.equal( requests.length, 2 );
+    assert.ok( requests[ 1 ].indexOf( 'since=2026-04-11T12%3A00%3A00Z' ) !== -1 );
+} );
+
+QUnit.test( 'GitHub API adapter honors Retry-After before retrying rate limits', async function( assert )
+{
+    var module = await modulePromise;
+    var calls = 0;
+    var delays = [];
+    var api = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        retry: {
+            attempts: 2,
+            baseDelayMs: 100,
+            maxDelayMs: 1000,
+            now: function() { return 0; },
+            sleep: async function( delay ) { delays.push( delay ); }
+        },
+        fetchImpl: async function()
+        {
+            calls++;
+            if( calls === 1 )
+            {
+                return new Response( JSON.stringify( { message: 'secondary rate limit' } ), {
+                    status: 429,
+                    headers: { 'Retry-After': '2' }
+                } );
+            }
+            return new Response( JSON.stringify( pullRequest() ), { status: 200 } );
+        }
+    } );
+
+    assert.equal( ( await api.getPullRequest( 19 ) ).number, 19 );
+    assert.equal( calls, 2 );
+    assert.deepEqual( delays, [ 2000 ] );
+} );
+
+QUnit.test( 'GitHub API adapter retries non-JSON server failures', async function( assert )
+{
+    var module = await modulePromise;
+    var calls = 0;
+    var delays = [];
+    var api = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        retry: {
+            attempts: 2,
+            baseDelayMs: 10,
+            maxDelayMs: 10,
+            sleep: async function( delay ) { delays.push( delay ); }
+        },
+        fetchImpl: async function()
+        {
+            calls++;
+            return calls === 1 ? new Response( '<html>', { status: 502 } ) :
+                new Response( JSON.stringify( pullRequest() ), { status: 200 } );
+        }
+    } );
+
+    assert.equal( ( await api.getPullRequest( 19 ) ).number, 19 );
+    assert.equal( calls, 2 );
+    assert.deepEqual( delays, [ 10 ] );
+} );

--- a/test/pr-vsix-preview.test.js
+++ b/test/pr-vsix-preview.test.js
@@ -1,0 +1,88 @@
+var path = require( 'path' );
+var pathToFileURL = require( 'url' ).pathToFileURL;
+
+var verifierPromise = import( pathToFileURL(
+    path.join( __dirname, '..', 'scripts', 'ci', 'verify-pr-vsix.mjs' )
+).href );
+var targets = require( '../scripts/release/targets.json' );
+
+function messageContains( fragment )
+{
+    return function( error )
+    {
+        return error && error.message.indexOf( fragment ) !== -1;
+    };
+}
+
+QUnit.module( 'PR VSIX preview verification' );
+
+QUnit.test( 'canonical targets resolve to seven unique native binaries', async function( assert )
+{
+    var verifier = await verifierPromise;
+    var expected = [
+        'extension/dist/ripgrep/darwin-arm64/rg',
+        'extension/dist/ripgrep/darwin-x64/rg',
+        'extension/dist/ripgrep/linux-arm/rg',
+        'extension/dist/ripgrep/linux-arm64/rg',
+        'extension/dist/ripgrep/linux-x64/rg',
+        'extension/dist/ripgrep/win32-arm64/rg.exe',
+        'extension/dist/ripgrep/win32-x64/rg.exe'
+    ];
+
+    assert.equal( targets.length, 10 );
+    assert.deepEqual( verifier.expectedRipgrepEntries( targets ), expected );
+    verifier.verifyTargetMap( targets );
+} );
+
+QUnit.test( 'entry verifier accepts only the exact native executable set and metadata', async function( assert )
+{
+    var verifier = await verifierPromise;
+    var entries = verifier.expectedRipgrepEntries( targets ).concat( [
+        'extension/dist/ripgrep/LICENSE',
+        'extension/dist/ripgrep/README.md',
+        'extension/dist/ripgrep/manifest.json'
+    ] );
+
+    assert.deepEqual( verifier.verifyEntrySet( entries, targets ), verifier.expectedRipgrepEntries( targets ) );
+    assert.throws( function()
+    {
+        verifier.verifyEntrySet( entries.slice( 1 ), targets );
+    }, messageContains( 'ripgrep entries mismatch' ) );
+    assert.throws( function()
+    {
+        verifier.verifyEntrySet( entries.concat( entries[ 0 ] ), targets );
+    }, messageContains( 'duplicate ripgrep executable entries' ) );
+    assert.throws( function()
+    {
+        verifier.verifyEntrySet( entries.filter( function( entry )
+        {
+            return entry !== 'extension/dist/ripgrep/LICENSE';
+        } ), targets );
+    }, messageContains( 'missing extension/dist/ripgrep/LICENSE' ) );
+} );
+
+QUnit.test( 'target map verifier rejects order and membership drift', async function( assert )
+{
+    var verifier = await verifierPromise;
+
+    assert.throws( function()
+    {
+        verifier.verifyTargetMap( targets.slice().reverse() );
+    }, messageContains( 'must match targets.json order and membership' ) );
+    assert.throws( function()
+    {
+        verifier.expectedRipgrepEntries( targets.concat( 'unknown-target' ) );
+    }, messageContains( 'Unsupported ripgrep target' ) );
+} );
+
+QUnit.test( 'executable mode verifier requires Unix execute bits', async function( assert )
+{
+    var verifier = await verifierPromise;
+    var entry = 'extension/dist/ripgrep/linux-x64/rg';
+
+    verifier.verifyExecutableModes( [ '-rwxr-xr-x  6.3 unx 1 b- 1 defN 00-Jan-01 00:00 ' + entry ], [ entry ] );
+    assert.throws( function()
+    {
+        verifier.verifyExecutableModes( [ '-rw-r--r--  6.3 unx 1 b- 1 defN 00-Jan-01 00:00 ' + entry ], [ entry ] );
+    }, messageContains( 'executable mode mismatch' ) );
+} );

--- a/test/pr-vsix-refresh.test.js
+++ b/test/pr-vsix-refresh.test.js
@@ -1,0 +1,788 @@
+var path = require( 'path' );
+var pathToFileURL = require( 'url' ).pathToFileURL;
+
+var contextModulePromise = import( pathToFileURL(
+    path.join( __dirname, '..', 'scripts', 'ci', 'resolve-pr-vsix-context.mjs' )
+).href );
+var refreshModulePromise = import( pathToFileURL(
+    path.join( __dirname, '..', 'scripts', 'ci', 'refresh-pr-vsix.mjs' )
+).href );
+
+var REPOSITORY = 'FanaticPythoner/better-todo-tree';
+var SHA_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+var SHA_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+var SHA_C = 'cccccccccccccccccccccccccccccccccccccccc';
+var SHA_D = 'dddddddddddddddddddddddddddddddddddddddd';
+
+function pullRequest( overrides )
+{
+    return Object.assign( {
+        number: 19,
+        state: 'open',
+        mergeable: true,
+        mergeable_state: 'clean',
+        merge_commit_sha: SHA_C,
+        author_association: 'OWNER',
+        labels: [],
+        head: { sha: SHA_A, repo: { id: 99 } },
+        base: { sha: SHA_B, ref: 'master', repo: { id: 1, full_name: REPOSITORY } }
+    }, overrides || {} );
+}
+
+function event( overrides )
+{
+    return Object.assign( {
+        repository: { full_name: REPOSITORY },
+        pull_request: pullRequest()
+    }, overrides || {} );
+}
+
+function markerBody( overrides )
+{
+    var values = Object.assign( {
+        source: 'ci',
+        action: 'synchronize',
+        runId: 200,
+        runAttempt: 1,
+        runNumber: 20,
+        observedAt: '2026-07-11T10:00:00Z',
+        headSha: SHA_A,
+        baseSha: SHA_B,
+        mergeSha: SHA_C,
+        phase: 'completed',
+        conclusion: 'success',
+        artifactId: 300,
+        artifactName: 'better-todo-tree-pr-19.vsix'
+    }, overrides || {} );
+    return [
+        '<!-- better-todo-tree-pr-vsix',
+        'source: ' + values.source,
+        'action: ' + values.action,
+        'run-id: ' + values.runId,
+        'run-attempt: ' + values.runAttempt,
+        'run-number: ' + values.runNumber,
+        'observed-at: ' + values.observedAt,
+        'head-sha: ' + values.headSha,
+        'base-sha: ' + values.baseSha,
+        'merge-sha: ' + values.mergeSha,
+        'phase: ' + values.phase,
+        'conclusion: ' + values.conclusion,
+        'artifact-id: ' + ( values.artifactId || 'none' ),
+        'artifact-name: ' + ( values.artifactName || 'none' ),
+        '-->'
+    ].join( '\n' );
+}
+
+function comment( body )
+{
+    return {
+        id: 400,
+        body: body,
+        issue_url: 'https://api.github.com/repos/FanaticPythoner/better-todo-tree/issues/19',
+        user: { login: 'github-actions[bot]' }
+    };
+}
+
+function storedArtifact( overrides )
+{
+    return Object.assign( {
+        id: 300,
+        name: 'better-todo-tree-pr-19.vsix',
+        expired: false,
+        expires_at: '2026-10-09T10:00:00Z',
+        workflow_run: { id: 200 }
+    }, overrides || {} );
+}
+
+QUnit.module( 'PR VSIX refresh and immutable context' );
+
+QUnit.test( 'base refresh accepts only successful same-repository push signals', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var baseEvent = {
+        action: 'completed',
+        repository: { id: 1, full_name: REPOSITORY },
+        workflow_run: {
+            name: 'PR VSIX Base Event',
+            event: 'push',
+            conclusion: 'success',
+            head_branch: 'release/1.x',
+            head_repository: { id: 1 }
+        }
+    };
+
+    assert.equal( module.workflowRunBaseBranch( baseEvent ), 'release/1.x' );
+    await assert.rejects( Promise.resolve().then( function()
+    {
+        return module.workflowRunBaseBranch( Object.assign( {}, baseEvent, {
+            workflow_run: Object.assign( {}, baseEvent.workflow_run, {
+                head_repository: { id: 2 }
+            } )
+        } ) );
+    } ), function( error )
+    {
+        return error.message.indexOf( 'same-repository push workflow' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'repository dispatch resolves only a parent-bound current merge context', async function( assert )
+{
+    var module = await contextModulePromise;
+    var dispatchEvent = event( {
+        action: 'refresh-pr-vsix',
+        pull_request: undefined,
+        client_payload: {
+            pull_request_number: 19,
+            head_sha: SHA_A,
+            base_sha: SHA_B,
+            merge_sha: SHA_C,
+            cause: 'repair'
+        }
+    } );
+    var api = {
+        getPullRequest: async function() { return pullRequest(); },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        }
+    };
+
+    var context = await module.resolveBuildContext( {
+        event: dispatchEvent,
+        api: api,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+    assert.equal( context.checkoutSha, SHA_C );
+    assert.ok( context.build );
+    assert.ok( module.renderOutputs( context ).indexOf( 'checkout-sha=' + SHA_C ) !== -1 );
+
+    dispatchEvent.client_payload.base_sha = SHA_D;
+    await assert.rejects( module.resolveBuildContext( {
+        event: dispatchEvent,
+        api: api,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } ), function( error )
+    {
+        return error.message.indexOf( 'build context changed during reconciliation' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'stale merge parents and unapproved external forks fail closed', async function( assert )
+{
+    var module = await contextModulePromise;
+    var dispatchEvent = event( {
+        action: 'refresh-pr-vsix',
+        pull_request: undefined,
+        client_payload: {
+            pull_request_number: 19,
+            head_sha: SHA_A,
+            base_sha: SHA_B,
+            merge_sha: SHA_C,
+            cause: 'repair'
+        }
+    } );
+    var staleApi = {
+        getPullRequest: async function() { return pullRequest(); },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_D }, { sha: SHA_A } ] };
+        }
+    };
+    await assert.rejects( module.resolveBuildContext( {
+        event: dispatchEvent,
+        api: staleApi,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } ), function( error )
+    {
+        return error.message.indexOf( 'merge context did not stabilize' ) !== -1;
+    } );
+
+    var external = pullRequest( {
+        author_association: 'NONE',
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var externalApi = {
+        getPullRequest: async function() { return external; },
+        getCommit: staleApi.getCommit
+    };
+    externalApi.getCommit = async function()
+    {
+        return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+    };
+    await assert.rejects( module.resolveBuildContext( {
+        event: dispatchEvent,
+        api: externalApi,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } ), function( error )
+    {
+        return error.message.indexOf( 'unauthorized, stale, or unmergeable' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'revocation dispatch resolves to trusted cleanup without PR checkout', async function( assert )
+{
+    var module = await contextModulePromise;
+    var external = pullRequest( {
+        author_association: 'NONE',
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var context = await module.resolveBuildContext( {
+        event: event( {
+            action: 'refresh-pr-vsix',
+            pull_request: undefined,
+            client_payload: {
+                pull_request_number: 19,
+                head_sha: SHA_A,
+                base_sha: SHA_B,
+                merge_sha: SHA_C,
+                cause: 'approval-revoked'
+            }
+        } ),
+        api: {
+            getPullRequest: async function() { return external; }
+        },
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+
+    assert.notOk( context.build );
+    assert.equal( context.checkoutSha, SHA_B );
+    assert.ok( module.renderOutputs( context ).indexOf( 'build=false' ) !== -1 );
+} );
+
+QUnit.test( 'closed repair resolves to trusted cleanup without PR checkout', async function( assert )
+{
+    var module = await contextModulePromise;
+    var closed = pullRequest( {
+        state: 'closed',
+        merge_commit_sha: SHA_D,
+        base: { sha: SHA_D, ref: 'master', repo: { id: 1, full_name: REPOSITORY } }
+    } );
+    var context = await module.resolveBuildContext( {
+        event: event( {
+            action: 'refresh-pr-vsix',
+            pull_request: undefined,
+            client_payload: {
+                pull_request_number: 19,
+                head_sha: SHA_A,
+                base_sha: SHA_B,
+                merge_sha: SHA_C,
+                cause: 'closed-repair'
+            }
+        } ),
+        api: {
+            getPullRequest: async function() { return closed; }
+        },
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+
+    assert.notOk( context.build );
+    assert.equal( context.checkoutSha, SHA_D );
+} );
+
+QUnit.test( 'cleanup dispatch never becomes an untrusted build after state reversal', async function( assert )
+{
+    var module = await contextModulePromise;
+    var approvalEvent = event( {
+        action: 'refresh-pr-vsix',
+        pull_request: undefined,
+        client_payload: {
+            pull_request_number: 19,
+            head_sha: SHA_A,
+            base_sha: SHA_B,
+            merge_sha: SHA_C,
+            cause: 'approval-revoked'
+        }
+    } );
+    var closeEvent = event( {
+        action: 'refresh-pr-vsix',
+        pull_request: undefined,
+        client_payload: Object.assign( {}, approvalEvent.client_payload, { cause: 'closed-repair' } )
+    } );
+    var api = {
+        getPullRequest: async function() { return pullRequest(); },
+        getCommit: async function()
+        {
+            assert.ok( false, 'cleanup reversal does not enter merge resolution' );
+        }
+    };
+
+    await assert.rejects( module.resolveBuildContext( {
+        event: approvalEvent,
+        api: api,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } ), function( error )
+    {
+        return error.message.indexOf( 'cleanup context is stale or inapplicable' ) !== -1;
+    } );
+    await assert.rejects( module.resolveBuildContext( {
+        event: closeEvent,
+        api: api,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } ), function( error )
+    {
+        return error.message.indexOf( 'cleanup context is stale or inapplicable' ) !== -1;
+    } );
+} );
+
+QUnit.test( 'scheduled refresh preserves current bundles outside the renewal window', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var refresh = module.requiresScheduledRefresh( {
+        pullRequest: pullRequest(),
+        comments: [ comment( markerBody() ) ],
+        artifacts: [ storedArtifact() ],
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000
+    } );
+
+    assert.notOk( refresh );
+} );
+
+QUnit.test( 'scheduled refresh repairs context drift, expiry, and abandoned pending state', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var input = {
+        pullRequest: pullRequest(),
+        comments: [ comment( markerBody() ) ],
+        artifacts: [ storedArtifact() ],
+        now: Date.parse( '2026-07-11T18:01:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000
+    };
+
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        comments: [ comment( markerBody( { baseSha: SHA_D } ) ) ]
+    } ) ) );
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        artifacts: [ storedArtifact( { expires_at: '2026-07-20T00:00:00Z' } ) ]
+    } ) ) );
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        artifacts: [ storedArtifact(), storedArtifact( { id: 301 } ) ]
+    } ) ) );
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        comments: [ comment( markerBody( {
+            phase: 'pending',
+            artifactId: undefined,
+            artifactName: undefined
+        } ) ) ],
+        artifacts: []
+    } ) ) );
+    assert.notOk( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        comments: [ comment( markerBody( {
+            phase: 'completed',
+            conclusion: 'failure',
+            artifactId: undefined,
+            artifactName: undefined
+        } ) ) ],
+        artifacts: []
+    } ) ) );
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        comments: [ comment( markerBody( {
+            phase: 'completed',
+            conclusion: 'failure',
+            artifactId: undefined,
+            artifactName: undefined
+        } ) ) ],
+        artifacts: [ storedArtifact() ]
+    } ) ) );
+    assert.ok( module.requiresScheduledRefresh( Object.assign( {}, input, {
+        comments: [ comment( markerBody( {
+            phase: 'completed',
+            conclusion: 'success',
+            artifactId: undefined,
+            artifactName: undefined
+        } ) ) ],
+        artifacts: []
+    } ) ) );
+} );
+
+QUnit.test( 'base refresh dispatches build and conflict invalidation events', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var dispatched = [];
+    var pulls = [
+        pullRequest(),
+        pullRequest( {
+            number: 20,
+            mergeable: false,
+            mergeable_state: 'dirty',
+            merge_commit_sha: null
+        } )
+    ];
+    var api = {
+        listOpenPullRequests: async function( base )
+        {
+            assert.equal( base, 'master' );
+            return pulls;
+        },
+        getPullRequest: async function( number )
+        {
+            return pulls.find( function( item ) { return item.number === number; } );
+        },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        base: 'master',
+        scheduled: false,
+        now: 0,
+        renewalWindowMs: 1,
+        pendingWindowMs: 1,
+        concurrency: 2,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+
+    assert.deepEqual( result, {
+        scanned: 2,
+        dispatched: 2,
+        current: 0,
+        skipped: 0,
+        revoked: 0,
+        unsafe: 0,
+        closedRepaired: 0
+    } );
+    dispatched.sort( function( left, right )
+    {
+        return left.payload.pull_request_number - right.payload.pull_request_number;
+    } );
+    assert.equal( dispatched[ 0 ].name, 'refresh-pr-vsix' );
+    assert.deepEqual( dispatched[ 0 ].payload, {
+        pull_request_number: 19,
+        head_sha: SHA_A,
+        base_sha: SHA_B,
+        merge_sha: SHA_C,
+        cause: 'base-push'
+    } );
+    assert.equal( dispatched[ 1 ].payload.merge_sha, 'none' );
+} );
+
+QUnit.test( 'base refresh returns a durable PR-number continuation cursor', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var pulls = [ pullRequest(), pullRequest( { number: 20 } ), pullRequest( { number: 21 } ) ];
+    var dispatched = [];
+    var api = {
+        listOpenPullRequests: async function() { return pulls; },
+        getPullRequest: async function( number )
+        {
+            return pulls.find( function( pull ) { return pull.number === number; } );
+        },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        base: 'master',
+        scheduled: false,
+        now: 0,
+        renewalWindowMs: 1,
+        pendingWindowMs: 1,
+        concurrency: 2,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        batchSize: 2
+    } );
+
+    assert.equal( result.scanned, 2 );
+    assert.equal( dispatched.length, 2 );
+    assert.deepEqual( result.continuation, { phase: 'open', cursor: 20 } );
+} );
+
+QUnit.test( 'continuation payload preserves scheduled and branch scan identity', async function( assert )
+{
+    var module = await refreshModulePromise;
+
+    assert.deepEqual( module.continuationInvocation( {
+        action: 'continue-pr-vsix-refresh',
+        client_payload: {
+            scheduled: false,
+            base: 'release/1.x',
+            phase: 'open',
+            cursor: 400
+        }
+    } ), {
+        base: 'release/1.x',
+        scheduled: false,
+        phase: 'open',
+        cursor: 400
+    } );
+} );
+
+QUnit.test( 'scheduled sweep dispatches only stale bundles', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var dispatched = [];
+    var api = {
+        listOpenPullRequests: async function() { return [ pullRequest() ]; },
+        getPullRequest: async function() { return pullRequest(); },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function()
+        {
+            return [ storedArtifact( { expires_at: '2026-07-12T00:00:00Z' } ) ];
+        },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z'
+    } );
+
+    assert.deepEqual( result, {
+        scanned: 1,
+        dispatched: 1,
+        current: 0,
+        skipped: 0,
+        revoked: 0,
+        unsafe: 0,
+        closedRepaired: 0
+    } );
+    assert.equal( dispatched.length, 1 );
+    assert.equal( dispatched[ 0 ].payload.cause, 'renewal' );
+} );
+
+QUnit.test( 'refresh sweep does not execute unapproved external fork code', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var dispatched = [];
+    var external = pullRequest( {
+        author_association: 'NONE',
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var api = {
+        listOpenPullRequests: async function() { return [ external ]; },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: false,
+        now: 0,
+        renewalWindowMs: 1,
+        pendingWindowMs: 1,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 }
+    } );
+
+    assert.deepEqual( result, {
+        scanned: 1,
+        dispatched: 0,
+        current: 0,
+        skipped: 0,
+        revoked: 0,
+        unsafe: 1,
+        closedRepaired: 0
+    } );
+    assert.deepEqual( dispatched, [] );
+} );
+
+QUnit.test( 'scheduled sweep reconciles revoked external preview state', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var dispatched = [];
+    var external = pullRequest( {
+        author_association: 'NONE',
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var api = {
+        listOpenPullRequests: async function() { return [ external ]; },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function() { return [ storedArtifact() ]; },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z'
+    } );
+
+    assert.deepEqual( result, {
+        scanned: 1,
+        dispatched: 0,
+        current: 0,
+        skipped: 0,
+        revoked: 1,
+        unsafe: 0,
+        closedRepaired: 0
+    } );
+    assert.equal( dispatched.length, 1 );
+    assert.equal( dispatched[ 0 ].payload.cause, 'approval-revoked' );
+} );
+
+QUnit.test( 'scheduled sweep reconciles artifacts orphaned by a missed close event', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var dispatched = [];
+    var closed = pullRequest( {
+        state: 'closed',
+        closed_at: '2026-07-11T10:30:00Z'
+    } );
+    var api = {
+        listOpenPullRequests: async function() { return []; },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function() { return [ storedArtifact() ]; },
+        getPullRequest: async function( number )
+        {
+            assert.equal( number, 19 );
+            return closed;
+        },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z',
+        phase: 'closed'
+    } );
+
+    assert.equal( result.closedRepaired, 1 );
+    assert.equal( dispatched.length, 1 );
+    assert.equal( dispatched[ 0 ].payload.cause, 'closed-repair' );
+} );
+
+QUnit.test( 'scheduled grouping ignores artifact namespaces without trusted bot metadata', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var grouped = module.groupScheduledState( [], [], [ storedArtifact() ] );
+
+    assert.deepEqual( grouped.closedCandidates, [] );
+    assert.equal( grouped.artifactsByName.size, 0 );
+} );
+
+QUnit.test( 'scheduled grouping retains orphan artifacts after blocked comment cleanup failure', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var blocked = comment( markerBody( {
+        phase: 'blocked',
+        artifactId: undefined,
+        artifactName: undefined
+    } ) );
+    var grouped = module.groupScheduledState( [ pullRequest() ], [ blocked ], [ storedArtifact() ] );
+
+    assert.equal( grouped.artifactsByName.get( 'better-todo-tree-pr-19.vsix' ).length, 1 );
+    assert.ok( module.requiresAuthorizationRevocation( {
+        pullRequest: pullRequest(),
+        comments: [ blocked ],
+        artifacts: grouped.artifactsByName.get( 'better-todo-tree-pr-19.vsix' )
+    } ) );
+} );
+
+QUnit.test( 'concurrent mapping processes all items before reporting failures', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var processed = [];
+    await assert.rejects( module.mapConcurrent( [ 1, 2, 3 ], 2, async function( value )
+    {
+        processed.push( value );
+        if( value === 2 )
+        {
+            throw new Error( 'fixture failure' );
+        }
+        return value;
+    } ), function( error )
+    {
+        return error instanceof AggregateError && error.errors.length === 1;
+    } );
+    assert.deepEqual( processed.sort(), [ 1, 2, 3 ] );
+} );
+
+QUnit.test( 'dispatch scheduler serializes mutations at the configured interval', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var clock = 0;
+    var dispatchedAt = [];
+    var dispatch = module.createDispatchScheduler( {
+        dispatchRepositoryEvent: async function()
+        {
+            dispatchedAt.push( clock );
+        }
+    }, {
+        intervalMs: 1000,
+        now: function() { return clock; },
+        sleep: async function( delay ) { clock += delay; }
+    } );
+
+    await Promise.all( [
+        dispatch( 'refresh-pr-vsix', { pull_request_number: 1 } ),
+        dispatch( 'refresh-pr-vsix', { pull_request_number: 2 } ),
+        dispatch( 'refresh-pr-vsix', { pull_request_number: 3 } )
+    ] );
+    assert.deepEqual( dispatchedAt, [ 0, 1000, 2000 ] );
+} );
+
+QUnit.test( 'dispatch scheduler holds the queue after an exhausted rate limit', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var clock = 0;
+    var calls = 0;
+    var dispatchedAt = [];
+    var dispatch = module.createDispatchScheduler( {
+        dispatchRepositoryEvent: async function()
+        {
+            calls++;
+            dispatchedAt.push( clock );
+            if( calls === 1 )
+            {
+                var error = new Error( 'rate limited' );
+                error.retryAfterMs = 5000;
+                throw error;
+            }
+        }
+    }, {
+        intervalMs: 1000,
+        now: function() { return clock; },
+        sleep: async function( delay ) { clock += delay; }
+    } );
+
+    var first = dispatch( 'refresh-pr-vsix', { pull_request_number: 1 } ).catch( function( error )
+    {
+        return error.message;
+    } );
+    var second = dispatch( 'refresh-pr-vsix', { pull_request_number: 2 } );
+    assert.equal( await first, 'rate limited' );
+    await second;
+    assert.deepEqual( dispatchedAt, [ 0, 5000 ] );
+} );

--- a/test/workflows.github.test.js
+++ b/test/workflows.github.test.js
@@ -8,6 +8,11 @@ var ACTION_REVISIONS = Object.freeze( {
         ref: '55cc8345863c7cc4c66a329aec7e433d2d1c52a9',
         version: 'v6.1.0'
     } ),
+    uploadArtifact: Object.freeze( {
+        action: 'actions/upload-artifact',
+        ref: '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+        version: 'v7.0.1'
+    } ),
     attestBuildProvenance: Object.freeze( {
         action: 'actions/attest-build-provenance',
         ref: '0f67c3f4856b2e3261c31976d6725780e5e4c373',
@@ -245,6 +250,18 @@ function getWorkflowJobBlock( contents, jobName )
     return lines.slice( start, end === -1 ? lines.length : end ).join( '\n' );
 }
 
+function getWorkflowStepBlock( contents, stepName )
+{
+    var marker = '      - name: ' + stepName;
+    var start = contents.indexOf( marker );
+    if( start === -1 )
+    {
+        return '';
+    }
+    var end = contents.indexOf( '\n      - name: ', start + marker.length );
+    return contents.slice( start, end === -1 ? contents.length : end );
+}
+
 function assertSecurityWorkflowContract( assert, securityWorkflow, label )
 {
     var references = getExternalActionReferences( securityWorkflow );
@@ -356,7 +373,7 @@ QUnit.test( 'release workflow requests provenance-related permissions', function
     assert.ok( contents.indexOf( 'contents: write' ) !== -1 );
 } );
 
-QUnit.test( 'cache and provenance workflow actions use Dependabot release SHAs', function( assert )
+QUnit.test( 'workflow actions use verified release SHAs', function( assert )
 {
     [ 'ci.yml', 'latest.yml', 'release.yml' ].forEach( function( workflowName )
     {
@@ -364,6 +381,10 @@ QUnit.test( 'cache and provenance workflow actions use Dependabot release SHAs',
     } );
 
     assertWorkflowActionRevision( assert, 'release.yml', ACTION_REVISIONS.attestBuildProvenance );
+    [ 'pr-vsix-build.yml', 'pr-vsix-event.yml' ].forEach( function( workflowName )
+    {
+        assertWorkflowActionRevision( assert, workflowName, ACTION_REVISIONS.uploadArtifact );
+    } );
 } );
 
 QUnit.test( 'latest workflow publishes a moving prerelease from master', function( assert )
@@ -433,13 +454,131 @@ QUnit.test( 'release workflows build and publish from the resolved release ref',
     assert.ok( verifyMarketplaceScript.indexOf( 'verify-vscode-marketplace.py' ) !== -1 );
 } );
 
-QUnit.test( 'ci workflow uploads only the smoke-test linux artifact', function( assert )
+QUnit.test( 'trusted PR workflow builds one verified cross-platform VSIX after all gates', function( assert )
+{
+    var buildWorkflow = readWorkflow( 'pr-vsix-build.yml' );
+    var testIndex = buildWorkflow.indexOf( 'run: npm test' );
+    var bundleIndex = buildWorkflow.indexOf( 'run: npm run vscode:prepublish' );
+    var previewIndex = buildWorkflow.indexOf( 'node scripts/release/build-vsix.mjs pr-preview' );
+    var verifyIndex = buildWorkflow.indexOf( 'node scripts/ci/verify-pr-vsix.mjs' );
+    var uploadIndex = buildWorkflow.indexOf( 'name: Upload PR VSIX bundle' );
+
+    assert.ok( buildWorkflow.indexOf( 'rm -rf artifacts/vsix' ) !== -1 );
+    [ testIndex, bundleIndex, previewIndex, verifyIndex, uploadIndex ].forEach( function( index )
+    {
+        assert.ok( index >= 0 );
+    } );
+    assert.ok( testIndex < bundleIndex );
+    assert.ok( bundleIndex < previewIndex );
+    assert.ok( previewIndex < verifyIndex );
+    assert.ok( verifyIndex < uploadIndex );
+    assert.ok( buildWorkflow.indexOf( 'name: better-todo-tree-pr-${{ steps.context.outputs.pull-request-number }}.vsix' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'path: artifacts/vsix/better-todo-tree-pr-${{ steps.context.outputs.pull-request-number }}.vsix' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'retention-days: 90' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'archive: false' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'overwrite: true' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'compression-level:' ) === -1 );
+    assert.ok( buildWorkflow.indexOf( 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'actions/cache' ) === -1 );
+    assert.ok( buildWorkflow.indexOf( 'timeout-minutes: 30' ) !== -1 );
+    [
+        'Check out immutable build context',
+        'Install dependencies',
+        'Run test suite',
+        'Build production bundle',
+        'Build PR VSIX bundle',
+        'Upload PR VSIX bundle'
+    ].forEach( function( stepName )
+    {
+        assert.ok(
+            getWorkflowStepBlock( buildWorkflow, stepName )
+                .indexOf( "if: steps.context.outputs.build == 'true'" ) !== -1,
+            stepName + ' is disabled for cleanup-only dispatches'
+        );
+    } );
+    assert.equal(
+        buildWorkflow.split( "if: steps.context.outputs.build == 'true'" ).length - 1,
+        6
+    );
+} );
+
+QUnit.test( 'trusted orchestration isolates and cancels only one PR generation', function( assert )
 {
     var ciWorkflow = readWorkflow( 'ci.yml' );
+    var buildWorkflow = readWorkflow( 'pr-vsix-build.yml' );
+    var eventWorkflow = readWorkflow( 'pr-vsix-event.yml' );
 
-    assert.ok( ciWorkflow.indexOf( 'rm -rf artifacts/vsix' ) !== -1 );
-    assert.ok( ciWorkflow.indexOf( 'artifacts/vsix/*-linux-x64.vsix' ) !== -1 );
-    assert.ok( ciWorkflow.indexOf( 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' ) !== -1 );
+    assert.ok( ciWorkflow.indexOf( 'pull_request:\n' ) !== -1 );
+    assert.ok( ciWorkflow.indexOf( 'edited' ) === -1 );
+    assert.ok( ciWorkflow.indexOf( 'github.event.pull_request.number || github.ref' ) !== -1 );
+    assert.ok( ciWorkflow.indexOf( 'cancel-in-progress: true' ) !== -1 );
+    assert.ok( ciWorkflow.indexOf( 'persist-credentials: false' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( "format('PR VSIX Build PR #{0} head {1} base {2} merge {3} action {4}'" ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'node scripts/ci/resolve-pr-vsix-context.mjs' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'ref: ${{ steps.context.outputs.checkout-sha }}' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'repository_dispatch:\n    types:\n      - refresh-pr-vsix' ) !== -1 );
+    assert.ok( buildWorkflow.indexOf( 'group: pr-vsix-build-${{ github.event.client_payload.pull_request_number }}' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( "format('pr-vsix-fallback-{0}', github.event.pull_request.number)" ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( "format('pr-vsix-build-{0}', github.event.pull_request.number)" ) !== -1 );
+} );
+
+QUnit.test( 'privileged PR VSIX publisher executes trusted metadata code only', function( assert )
+{
+    var workflow = readWorkflow( 'pr-vsix-comment.yml' );
+    var baseEventWorkflow = readWorkflow( 'pr-vsix-base-event.yml' );
+    var eventWorkflow = readWorkflow( 'pr-vsix-event.yml' );
+    var refreshWorkflow = readWorkflow( 'pr-vsix-refresh.yml' );
+
+    assert.ok( workflow.indexOf( 'workflow_run:' ) !== -1 );
+    assert.ok( workflow.indexOf( 'pull_request_target:' ) === -1 );
+    assert.ok( workflow.indexOf( '      - PR VSIX Build' ) !== -1 );
+    assert.ok( workflow.indexOf( '      - PR VSIX Event' ) !== -1 );
+    assert.ok( workflow.indexOf( '      - in_progress\n      - completed' ) !== -1 );
+    assert.ok( workflow.indexOf( "github.event.workflow_run.name == 'PR VSIX Build'" ) !== -1 );
+    assert.ok( workflow.indexOf( "github.event.workflow_run.name == 'PR VSIX Event'" ) !== -1 );
+    assert.ok( workflow.indexOf( 'actions: write' ) !== -1 );
+    assert.ok( workflow.indexOf( 'permissions: {}' ) !== -1 );
+    assert.ok( workflow.indexOf( '      contents: read' ) !== -1 );
+    assert.ok( workflow.indexOf( '      contents: write' ) !== -1 );
+    assert.ok( workflow.indexOf( 'pull-requests: write' ) !== -1 );
+    assert.ok( workflow.indexOf( 'ref: ${{ github.event.repository.default_branch }}' ) !== -1 );
+    assert.ok( workflow.indexOf( 'persist-credentials: false' ) !== -1 );
+    assert.ok( workflow.indexOf( 'node scripts/ci/sync-pr-vsix-comment.mjs' ) !== -1 );
+    assert.ok( workflow.indexOf( 'download-artifact' ) === -1 );
+    assert.ok( workflow.indexOf( 'node scripts/ci/sync-pr-vsix-comment.mjs resolve >> "$GITHUB_OUTPUT"' ) !== -1 );
+    assert.ok( workflow.indexOf( "if: needs.resolve.outputs.processable == 'true'" ) !== -1 );
+    assert.ok( workflow.indexOf( 'group: pr-vsix-comment-${{ needs.resolve.outputs.pull-request-number }}' ) !== -1 );
+    assert.ok( workflow.indexOf( 'cancel-in-progress: false' ) !== -1 );
+    assert.ok( workflow.indexOf( 'timeout-minutes: 75' ) !== -1 );
+    assert.ok( workflow.indexOf( 'PR_VSIX_API_RETRY_ATTEMPTS: 4' ) !== -1 );
+    assert.ok( workflow.indexOf( 'github.event.workflow_run.head_sha }}\n          fetch-depth' ) === -1 );
+    assert.ok( eventWorkflow.indexOf( 'pull_request:\n    types:\n      - closed\n      - edited\n      - labeled\n      - unlabeled\n      - opened\n      - reopened\n      - synchronize' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'pull_request_target:\n    types:\n      - closed\n      - edited\n      - labeled\n      - unlabeled\n      - opened\n      - reopened\n      - synchronize' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( "github.event.action != 'edited' || github.event.changes.base != null" ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( "github.event.action != 'labeled' && github.event.action != 'unlabeled'" ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( '-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'actions/checkout' ) === -1 );
+    assert.ok( eventWorkflow.indexOf( 'permissions: {}' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'pull-requests: write' ) === -1 );
+    assert.ok( baseEventWorkflow.indexOf( 'push:\n    branches:\n      - "**"' ) !== -1 );
+    assert.ok( baseEventWorkflow.indexOf( 'permissions: {}' ) !== -1 );
+    assert.ok( baseEventWorkflow.indexOf( 'actions/' ) === -1 );
+    assert.ok( baseEventWorkflow.indexOf( 'group: pr-vsix-base-event-${{ github.ref }}' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'schedule:' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'workflow_run:' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'repository_dispatch:\n    types:\n      - continue-pr-vsix-refresh' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( '      - PR VSIX Base Event' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'actions: read' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'contents: write' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'node scripts/ci/refresh-pr-vsix.mjs' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'timeout-minutes: 180' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'PR_VSIX_DISPATCH_INTERVAL_MS: 1000' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'PR_VSIX_REFRESH_BATCH_SIZE: 400' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'persist-credentials: false' ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( 'push:\n    branches:' ) === -1 );
+    assert.ok( refreshWorkflow.indexOf( "format('branch-{0}', github.event.workflow_run.head_branch)" ) !== -1 );
+    assert.ok( refreshWorkflow.indexOf( "format('continuation-{0}', github.event.client_payload.base || 'all')" ) !== -1 );
 } );
 
 QUnit.test( 'VSIX builder stages one ripgrep-universal binary for each native target', function( assert )
@@ -448,14 +587,27 @@ QUnit.test( 'VSIX builder stages one ripgrep-universal binary for each native ta
 
     assert.ok( buildScript.indexOf( "node_modules', '@vscode', 'ripgrep-universal'" ) !== -1 );
     assert.ok( buildScript.indexOf( "import { binPathFor } from '@vscode/ripgrep-universal';" ) !== -1 );
-    assert.ok( buildScript.indexOf( "['linux-armhf', Object.freeze({ os: 'linux', arch: 'arm' })]" ) !== -1 );
-    assert.ok( buildScript.indexOf( "['alpine-x64', Object.freeze({ os: 'linux', arch: 'x64' })]" ) !== -1 );
-    assert.ok( buildScript.indexOf( "['alpine-arm64', Object.freeze({ os: 'linux', arch: 'arm64' })]" ) !== -1 );
+    assert.ok( buildScript.indexOf( "from './ripgrep-targets.mjs'" ) !== -1 );
     assert.ok( buildScript.indexOf( "fs.chmodSync(destinationPath, platform.os === 'win32' ? 0o644 : 0o755)" ) !== -1 );
     assert.ok( buildScript.indexOf( "copyRipgrepPackageFile('LICENSE')" ) !== -1 );
     assert.ok( buildScript.indexOf( "const { pack } = require('@vscode/vsce/out/package.js')" ) !== -1 );
     assert.ok( buildScript.indexOf( 'dependencies: false' ) !== -1 );
     assert.ok( buildScript.indexOf( 'finally {\n        resetRipgrepStage();\n    }' ) !== -1 );
+} );
+
+QUnit.test( 'VSIX builder exposes an untargeted universal PR preview mode', function( assert )
+{
+    var buildScript = readRepositoryFile( path.join( 'scripts', 'release', 'build-vsix.mjs' ) );
+    var targetScript = readRepositoryFile( path.join( 'scripts', 'release', 'ripgrep-targets.mjs' ) );
+    var verifyScript = readRepositoryFile( path.join( 'scripts', 'ci', 'verify-pr-vsix.mjs' ) );
+
+    assert.ok( buildScript.indexOf( "const previewTarget = 'pr-preview'" ) !== -1 );
+    assert.ok( buildScript.indexOf( 'stageRipgrepForPreview(selectedTargets)' ) !== -1 );
+    assert.ok( buildScript.indexOf( 'await packageTarget(undefined, outputPath)' ) !== -1 );
+    assert.ok( buildScript.indexOf( 'PR_VSIX_FILENAME' ) !== -1 );
+    assert.ok( targetScript.indexOf( 'function uniqueNativePlatforms' ) !== -1 );
+    assert.ok( verifyScript.indexOf( 'TargetPlatform=' ) !== -1 );
+    assert.ok( verifyScript.indexOf( "runUnzip(['-tqq', resolvedPath])" ) !== -1 );
 } );
 
 QUnit.test( 'VSIX builder removes stale selected target outputs before packing', function( assert )
@@ -562,6 +714,7 @@ QUnit.test( 'justfile exposes GitHub Actions verification recipes', function( as
     assert.ok( justfile.indexOf( 'bootstrap-release-env:' ) !== -1 );
     assert.ok( justfile.indexOf( 'lint-actions:' ) !== -1 );
     assert.ok( justfile.indexOf( 'test-actions-ci:' ) !== -1 );
+    assert.ok( justfile.indexOf( 'test-actions-pr-vsix-build:' ) !== -1 );
     assert.ok( justfile.indexOf( 'test-actions-release-build:' ) !== -1 );
     assert.ok( justfile.indexOf( 'test-actions-latest-build:' ) !== -1 );
     assert.ok( justfile.indexOf( 'test-actions:' ) !== -1 );


### PR DESCRIPTION
Build immutable PR merge commits into one verified preview and keep artifact
publication, revocation, renewal, and repair scoped per pull request.

Trust and packaging:
- authorize same-repository and trusted-author PRs automatically and gate other
  external forks on `safe-to-test`
- isolate permissionless lifecycle signals and read-only builds from trusted
  comment and artifact mutations
- verify merge parents before checkout and revalidate PR identity,
  authorization, and immutable SHAs before publication
- package every unique configured desktop ripgrep binary into one untargeted
  VSIX while preserving targeted release builds
- reject archive, target-map, metadata, executable-mode, or binary-set drift
  before artifact upload

Lifecycle and recovery:
- rebuild after head, base, reopen, and approval changes with per-PR
  cancellation and serialized publication
- maintain one ordered comment with source SHA, SHA-256 digest, expiration,
  security guidance, and direct download and workflow links
- withhold stale links during transitions and remove duplicate, superseded,
  revoked, expired, and closed-PR artifacts
- repair or renew previews through base-push, scheduled, manual, and
  continuation-driven reconciliation
- paginate repository scans, bound concurrent batches, persist cursors, pace
  dispatches, and honor API retry delays

CI and coverage:
- harden CI checkout, timeout, and cancellation boundaries and retire the
  redundant smoke-test artifact upload
- add preview packaging, context, authorization, race, cleanup, refresh,
  workflow-permission, and release-compatibility coverage
