### PR TITLE
fix: preserve PR identity in VSIX lifecycle run names

### DIFF
--- a/.github/workflows/pr-vsix-event.yml
+++ b/.github/workflows/pr-vsix-event.yml
@@ -1,5 +1,6 @@
 name: PR VSIX Event
-run-name: PR VSIX Event #${{ github.event.pull_request.number }} ${{ github.event.action }}
+run-name: >-
+  ${{ format('PR VSIX Event #{0} {1}', github.event.pull_request.number, github.event.action) }}
 
 on:
   pull_request:

--- a/test/pr-vsix-comment.test.js
+++ b/test/pr-vsix-comment.test.js
@@ -1049,6 +1049,19 @@ QUnit.test( 'workflow identity resolver covers CI and lifecycle events', async f
         pullRequestNumber: 19,
         processable: true
     } );
+    var malformedLifecycleError;
+    try
+    {
+        module.resolveWorkflowIdentity( lifecycleRun( {
+            display_title: 'PR VSIX Event'
+        } ) );
+    }
+    catch( error )
+    {
+        malformedLifecycleError = error;
+    }
+    assert.ok( malformedLifecycleError instanceof module.PrVsixInvariantError );
+    assert.equal( malformedLifecycleError.message, 'workflow run: expected a canonical PR identity' );
 } );
 
 QUnit.test( 'GitHub API adapter paginates and dispatches refresh events', async function( assert )

--- a/test/workflows.github.test.js
+++ b/test/workflows.github.test.js
@@ -341,6 +341,33 @@ QUnit.test( 'external workflow actions are pinned to full commit SHAs', function
     } );
 } );
 
+QUnit.test( 'workflow run names preserve hash characters', function( assert )
+{
+    getWorkflowPaths().forEach( function( workflowPath )
+    {
+        var contents = fs.readFileSync( workflowPath, 'utf8' );
+        var relativePath = path.relative( path.join( __dirname, '..' ), workflowPath );
+        var unsafeRunNameLine = contents
+            .split( regexRegistry.createRegExp( 'optionalCarriageReturnLineBreak' ) )
+            .find( function( line )
+            {
+                if( line.indexOf( 'run-name: ' ) !== 0 )
+                {
+                    return false;
+                }
+
+                var value = line.slice( 'run-name: '.length );
+                return ![ '>', '|', "'", '"' ].includes( value[ 0 ] ) && value.indexOf( ' #' ) !== -1;
+            } );
+
+        assert.equal(
+            unsafeRunNameLine,
+            undefined,
+            relativePath + ': plain YAML run-name cannot contain whitespace-hash'
+        );
+    } );
+} );
+
 QUnit.test( 'Dependabot groups CodeQL action revisions atomically', function( assert )
 {
     var githubActionsUpdates = getDependabotUpdateBlocks(
@@ -518,6 +545,13 @@ QUnit.test( 'trusted orchestration isolates and cancels only one PR generation',
     assert.ok( buildWorkflow.indexOf( 'ref: ${{ steps.context.outputs.checkout-sha }}' ) !== -1 );
     assert.ok( buildWorkflow.indexOf( 'repository_dispatch:\n    types:\n      - refresh-pr-vsix' ) !== -1 );
     assert.ok( buildWorkflow.indexOf( 'group: pr-vsix-build-${{ github.event.client_payload.pull_request_number }}' ) !== -1 );
+    assert.ok(
+        eventWorkflow.indexOf( [
+            'run-name: >-',
+            "  ${{ format('PR VSIX Event #{0} {1}', github.event.pull_request.number, github.event.action) }}"
+        ].join( '\n' ) ) !== -1,
+        'lifecycle run name preserves PR and action identity'
+    );
     assert.ok( eventWorkflow.indexOf( "format('pr-vsix-fallback-{0}', github.event.pull_request.number)" ) !== -1 );
     assert.ok( eventWorkflow.indexOf( "format('pr-vsix-build-{0}', github.event.pull_request.number)" ) !== -1 );
 } );


### PR DESCRIPTION
Render lifecycle run names through a folded `format()` expression so YAML preserves the PR number and action after `#` for comment synchronization.

Guard every workflow run name against whitespace-hash truncation while keeping malformed lifecycle identities fail-closed.