### PR TITLE
fix: harden PR VSIX context reconciliation

### DIFF
--- a/.github/workflows/pr-vsix-event.yml
+++ b/.github/workflows/pr-vsix-event.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload lifecycle marker
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-${{ github.event.pull_request.merge_commit_sha || 'none' }}-${{ github.event.action }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          name: better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-none-${{ github.event.action }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
           path: pr-vsix-event
           if-no-files-found: error
           retention-days: 1

--- a/scripts/ci/refresh-pr-vsix.mjs
+++ b/scripts/ci/refresh-pr-vsix.mjs
@@ -37,6 +37,10 @@ function metadataMatchesContext(metadata, context) {
         metadata.mergeSha === context.mergeSha;
 }
 
+function metadataMatchesSource(metadata, context) {
+    return metadata.headSha === context.headSha && metadata.baseSha === context.baseSha;
+}
+
 function scheduledRefreshCause({ pullRequest, context, comments, artifacts, now, renewalWindowMs, pendingWindowMs }) {
     const metadata = managedMetadata(comments).find((candidate) =>
         metadataMatchesContext(candidate, context)
@@ -74,7 +78,7 @@ function scheduledRefreshCause({ pullRequest, context, comments, artifacts, now,
 }
 
 function requiresScheduledRefresh(options) {
-    return scheduledRefreshCause({ ...options, context: pullRequestContext(options.pullRequest) }) !== undefined;
+    return scheduledRefreshCause(options) !== undefined;
 }
 
 function refreshPayload(context, cause) {
@@ -207,7 +211,7 @@ function groupScheduledState(pullRequests, comments, artifacts) {
 function requiresAuthorizationRevocation({ pullRequest, comments, artifacts }) {
     const context = pullRequestContext(pullRequest);
     const metadata = managedMetadata(comments);
-    const currentBlocked = metadata.length === 1 && metadataMatchesContext(metadata[0], context) &&
+    const currentBlocked = metadata.length === 1 && metadataMatchesSource(metadata[0], context) &&
         metadata[0].phase === 'blocked';
     return !currentBlocked || artifacts.length > 0;
 }
@@ -268,21 +272,6 @@ async function refreshOpenPullRequests({
             }
             return 'unsafe';
         }
-        let cause = 'base-push';
-        if (scheduled) {
-            cause = scheduledRefreshCause({
-                pullRequest: listedPullRequest,
-                context: pullRequestContext(listedPullRequest),
-                comments,
-                artifacts,
-                now,
-                renewalWindowMs,
-                pendingWindowMs
-            });
-            if (!cause) {
-                return 'current';
-            }
-        }
         const stable = await waitForStablePullRequest({
             api,
             pullRequestNumber: listedPullRequest.number,
@@ -290,11 +279,34 @@ async function refreshOpenPullRequests({
             expectedBaseSha: listedPullRequest.base.sha,
             retry: mergeRetry
         });
+        if (stable.pullRequest.state === 'closed') {
+            await dispatchRepositoryEvent(
+                'refresh-pr-vsix',
+                refreshPayload(stable.context, 'closed-repair')
+            );
+            return 'closed-repaired';
+        }
         if (stable.pullRequest.state !== 'open') {
             return 'skipped';
         }
         if (!automaticBuildAllowed(stable.pullRequest)) {
-            return 'unsafe';
+            await dispatchRepositoryEvent(
+                'refresh-pr-vsix',
+                refreshPayload(stable.context, 'approval-revoked')
+            );
+            return 'revoked';
+        }
+        const cause = scheduled ? scheduledRefreshCause({
+            pullRequest: stable.pullRequest,
+            context: stable.context,
+            comments,
+            artifacts,
+            now,
+            renewalWindowMs,
+            pendingWindowMs
+        }) : 'base-push';
+        if (!cause) {
+            return 'current';
         }
         await dispatchRepositoryEvent('refresh-pr-vsix', refreshPayload(stable.context, cause));
         return 'dispatched';
@@ -344,7 +356,8 @@ async function refreshOpenPullRequests({
         skipped: decisions.filter((decision) => decision === 'skipped').length,
         revoked: decisions.filter((decision) => decision === 'revoked').length,
         unsafe: decisions.filter((decision) => decision === 'unsafe').length,
-        closedRepaired: closedDecisions.filter((decision) => decision === 'repaired').length,
+        closedRepaired: decisions.filter((decision) => decision === 'closed-repaired').length +
+            closedDecisions.filter((decision) => decision === 'repaired').length,
         ...(continuation ? { continuation } : {})
     });
 }

--- a/scripts/ci/sync-pr-vsix-comment.mjs
+++ b/scripts/ci/sync-pr-vsix-comment.mjs
@@ -9,6 +9,9 @@ const ARTIFACT_NAME_PREFIX = 'better-todo-tree-pr-';
 const EXTERNAL_APPROVAL_REASON = 'External fork previews require maintainer approval with the `safe-to-test` label.';
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const ERROR_CODE_CONTEXT_CHANGED = 'PR_CONTEXT_CHANGED';
+const ERROR_CODE_MERGE_CHANGED = 'PR_MERGE_CONTEXT_CHANGED';
+const ERROR_CODE_MERGE_UNSTABLE = 'PR_MERGE_CONTEXT_UNSTABLE';
 const CI_ACTIONS = new Set([
     'approval-revoked',
     'base-edited',
@@ -33,6 +36,8 @@ class PrVsixInvariantError extends Error {
         this.status = options && options.status;
         this.retryable = Boolean(options && options.retryable);
         this.retryAfterMs = options && options.retryAfterMs;
+        this.code = options && options.code;
+        this.canonicalMergeSha = options && options.canonicalMergeSha;
     }
 }
 
@@ -262,10 +267,74 @@ function contextMatches(left, right) {
 }
 
 function phaseRank(phase) {
-    return phase === 'completed' ? 2 : 1;
+    return phase === 'completed' ? 3 : phase === 'blocked' ? 2 : 1;
+}
+
+function compareCommentState(left, right) {
+    if (left.source === right.source && Number.isSafeInteger(left.runNumber) &&
+        Number.isSafeInteger(right.runNumber)) {
+        const generation = compareSequence(left, right);
+        if (generation !== 0) {
+            return generation;
+        }
+        const phase = phaseRank(left.phase) - phaseRank(right.phase);
+        if (phase !== 0) {
+            return phase;
+        }
+    }
+    const observed = timestamp(left.startedAt, 'comment observation time') -
+        timestamp(right.startedAt, 'comment observation time');
+    if (observed !== 0) {
+        return observed;
+    }
+    if (left.source !== right.source) {
+        return left.source === 'ci' ? 1 : -1;
+    }
+    return left.runId - right.runId;
+}
+
+function failureStateDominates(existing, incoming) {
+    if (incoming.authorizationRevoked) {
+        return false;
+    }
+    if (!existing.startedAt || existing.headSha !== incoming.headSha ||
+        existing.baseSha !== incoming.baseSha) {
+        return false;
+    }
+    if (incoming.canonicalMergeSha) {
+        return existing.phase !== 'closed' && existing.mergeSha === incoming.canonicalMergeSha;
+    }
+    if (existing.source === incoming.source) {
+        const generation = compareSequence(existing, incoming);
+        if (generation !== 0) {
+            return generation > 0;
+        }
+        const sameRun = existing.runId === incoming.id;
+        if (incoming.invalidatesArtifact && sameRun) {
+            return false;
+        }
+        const observed = timestamp(existing.startedAt, 'comment observation time') -
+            timestamp(incoming.startedAt, 'workflow observation time');
+        if (observed !== 0) {
+            return observed > 0;
+        }
+        if (!sameRun) {
+            return existing.runId > incoming.id;
+        }
+        return phaseRank(existing.phase) > phaseRank(incoming.phase);
+    }
+    const observed = timestamp(existing.startedAt, 'comment observation time') -
+        timestamp(incoming.startedAt, 'workflow observation time');
+    if (observed !== 0) {
+        return observed > 0;
+    }
+    return existing.source === 'ci';
 }
 
 function existingStateDominates(existing, incoming) {
+    if (incoming.failureState) {
+        return failureStateDominates(existing, incoming);
+    }
     if (!existing.source || !existing.runNumber || !existing.startedAt || !existing.baseSha || !existing.mergeSha ||
         !contextMatches(existing, incoming) || incoming.phase === 'closed' || existing.phase === 'closed') {
         return false;
@@ -356,6 +425,193 @@ function renderUnavailableComment({ repository, run, reason }) {
         '',
         `[Workflow run](${runUrl(repository, run.id)})`
     ].join('\n');
+}
+
+function synchronizationFailureReason(error) {
+    if (error && error.code === ERROR_CODE_MERGE_UNSTABLE) {
+        return 'GitHub did not expose an immutable merge ref matching the current base and head.';
+    }
+    if (error && error.code === ERROR_CODE_CONTEXT_CHANGED) {
+        return 'The pull request source changed during preview reconciliation.';
+    }
+    if (error && error.code === ERROR_CODE_MERGE_CHANGED) {
+        return 'The pull request merge ref changed before preview publication.';
+    }
+    if (error instanceof PrVsixInvariantError && error.message.includes('invalid merge ref response')) {
+        return 'GitHub returned an invalid pull request merge-ref response.';
+    }
+    if (error instanceof PrVsixInvariantError && error.message.startsWith('GitHub API ')) {
+        return 'GitHub API access failed during preview reconciliation.';
+    }
+    return 'Preview orchestration failed before a verified bundle could be published.';
+}
+
+async function publishSynchronizationFailure({ api, repository, run, error, retainedRun, onStale, mergeRetry }) {
+    let pullRequest;
+    let currentContext;
+    let baseRepository;
+    try {
+        pullRequest = await api.getPullRequest(run.pullRequestNumber);
+        currentContext = pullRequestContext(pullRequest);
+        baseRepository = pullRequest.base && pullRequest.base.repo;
+    } catch (reconciliationError) {
+        throw new AggregateError(
+            [error, reconciliationError],
+            'PR VSIX synchronization and current-source revalidation failed'
+        );
+    }
+    const baseRepositoryMatches = baseRepository && baseRepository.full_name === repository;
+    const sourceMatches = currentContext.headSha === run.headSha && currentContext.baseSha === run.baseSha;
+    const authorizationRevoked = pullRequest.state === 'open' && baseRepositoryMatches &&
+        !automaticBuildAllowed(pullRequest);
+    if (pullRequest.state === 'closed' && baseRepositoryMatches) {
+        const closedRun = Object.freeze({ ...run, ...currentContext, phase: 'closed' });
+        try {
+            await reconcileNamespaceInvalidation({
+                api,
+                pullRequestNumber: closedRun.pullRequestNumber,
+                body: renderClosedComment({ repository, run: closedRun }),
+                run: closedRun
+            });
+        } catch (reconciliationError) {
+            throw new AggregateError(
+                [error, reconciliationError],
+                'PR VSIX synchronization and closed-state reconciliation failed'
+            );
+        }
+        throw error;
+    }
+    if (pullRequest.state !== 'open' || !baseRepositoryMatches || !sourceMatches && !authorizationRevoked) {
+        if (onStale) {
+            try {
+                await onStale();
+            } catch (reconciliationError) {
+                throw new AggregateError(
+                    [error, reconciliationError],
+                    'PR VSIX synchronization and stale-run cleanup failed'
+                );
+            }
+        }
+        throw error;
+    }
+    if (error && error.code === ERROR_CODE_MERGE_CHANGED && !authorizationRevoked && mergeRetry) {
+        let stable;
+        try {
+            stable = await waitForStablePullRequest({
+                api,
+                pullRequestNumber: run.pullRequestNumber,
+                expectedHeadSha: run.headSha,
+                expectedBaseSha: run.baseSha,
+                retry: mergeRetry
+            });
+        } catch (revalidationError) {
+            if (revalidationError && revalidationError.code === ERROR_CODE_CONTEXT_CHANGED && onStale) {
+                try {
+                    await onStale();
+                } catch (cleanupError) {
+                    throw new AggregateError(
+                        [error, revalidationError, cleanupError],
+                        'PR VSIX merge revalidation and stale-run cleanup failed'
+                    );
+                }
+                throw error;
+            }
+            error = new PrVsixInvariantError(
+                `pull request ${run.pullRequestNumber}: merge context changed and could not be revalidated`,
+                {
+                    cause: new AggregateError([error, revalidationError]),
+                    code: ERROR_CODE_MERGE_CHANGED
+                }
+            );
+        }
+        if (stable && stable.buildable && stable.context.mergeSha === run.mergeSha) {
+            return stable.pullRequest;
+        }
+        if (stable) {
+            error = new PrVsixInvariantError(
+                `pull request ${run.pullRequestNumber}: merge context changed before publication`,
+                { code: ERROR_CODE_MERGE_CHANGED, canonicalMergeSha: stable.context.mergeSha }
+            );
+            const stableRepository = stable.pullRequest.base && stable.pullRequest.base.repo;
+            const stableSourceMatches = stable.context.headSha === run.headSha &&
+                stable.context.baseSha === run.baseSha;
+            const stableAuthorizationRevoked = stable.pullRequest.state === 'open' && stableRepository &&
+                stableRepository.full_name === repository && !automaticBuildAllowed(stable.pullRequest);
+            if (stable.pullRequest.state !== pullRequest.state ||
+                !stableRepository || stableRepository.full_name !== repository ||
+                !stableSourceMatches || stableAuthorizationRevoked) {
+                return publishSynchronizationFailure({
+                    api,
+                    repository,
+                    run,
+                    error,
+                    retainedRun,
+                    onStale
+                });
+            }
+        }
+    }
+    const invalidatesArtifact = authorizationRevoked || error && error.code === ERROR_CODE_MERGE_CHANGED;
+    const failedRun = Object.freeze({
+        ...run,
+        ...(authorizationRevoked ? currentContext : {}),
+        phase: 'blocked',
+        failureState: true,
+        invalidatesArtifact,
+        authorizationRevoked,
+        canonicalMergeSha: error && error.canonicalMergeSha
+    });
+    if (authorizationRevoked) {
+        try {
+            await reconcileNamespaceInvalidation({
+                api,
+                pullRequestNumber: failedRun.pullRequestNumber,
+                body: renderUnavailableComment({
+                    repository,
+                    run: failedRun,
+                    reason: EXTERNAL_APPROVAL_REASON
+                }),
+                run: failedRun
+            });
+        } catch (reconciliationError) {
+            throw new AggregateError(
+                [error, reconciliationError],
+                'PR VSIX synchronization and authorization-revocation reconciliation failed'
+            );
+        }
+        throw error;
+    }
+    const retainedArtifactRun = retainedRun;
+    const cleanup = ({ replacedStates = [], retainedStates = [] } = {}) => removeFailureArtifacts(
+        api,
+        failedRun.pullRequestNumber,
+        failedRun,
+        retainedArtifactRun,
+        replacedStates.map((state) => state.artifactId).filter(Boolean),
+        retainedStates.map((state) => state.artifactId).filter(Boolean)
+    );
+    try {
+        const comment = await upsertComment(
+            api,
+            failedRun.pullRequestNumber,
+            renderUnavailableComment({
+                repository,
+                run: failedRun,
+                reason: authorizationRevoked ? EXTERNAL_APPROVAL_REASON : synchronizationFailureReason(error)
+            }),
+            failedRun,
+            (replacedStates) => cleanup({ replacedStates })
+        );
+        if (!comment.applied) {
+            await cleanup(comment);
+        }
+    } catch (reconciliationError) {
+        throw new AggregateError(
+            [error, reconciliationError],
+            'PR VSIX synchronization and terminal comment reconciliation failed'
+        );
+    }
+    throw error;
 }
 
 function renderPendingComment({ repository, run }) {
@@ -500,7 +756,12 @@ function createGitHubApi({
         return rateLimitGate;
     }
 
-    async function requestOnce(relativePath, { method = 'GET', body, expectedStatuses = [200] } = {}) {
+    async function requestOnce(relativePath, {
+        method = 'GET',
+        body,
+        expectedStatuses = [200],
+        includeStatus = false
+    } = {}) {
         let response;
         try {
             response = await fetchImpl(`${apiUrl}${relativePath}`, {
@@ -551,7 +812,7 @@ function createGitHubApi({
             const detail = responseBody && responseBody.message ? responseBody.message : responseText.slice(0, 1000);
             throw httpError(detail);
         }
-        return responseBody;
+        return includeStatus ? Object.freeze({ status: response.status, body: responseBody }) : responseBody;
     }
 
     async function request(relativePath, options) {
@@ -602,6 +863,23 @@ function createGitHubApi({
     return Object.freeze({
         getPullRequest(number) {
             return request(`${repositoryPath}/pulls/${requireInteger(number, 'pull request number')}`);
+        },
+        async getPullRequestMergeSha(number) {
+            const pullRequestNumber = requireInteger(number, 'pull request number');
+            const expectedRef = `refs/pull/${pullRequestNumber}/merge`;
+            const response = await request(`${repositoryPath}/git/ref/pull/${pullRequestNumber}/merge`, {
+                expectedStatuses: [200, 404, 409],
+                includeStatus: true
+            });
+            if (response.status !== 200) {
+                return undefined;
+            }
+            const reference = response.body;
+            if (!reference || reference.ref !== expectedRef || !reference.object ||
+                reference.object.type !== 'commit') {
+                throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: invalid merge ref response`);
+            }
+            return requireSha(reference.object.sha, 'pull request merge ref SHA');
         },
         getCommit(sha) {
             return request(`${repositoryPath}/commits/${requireSha(sha, 'commit SHA')}`);
@@ -672,20 +950,12 @@ function createGitHubApi({
     });
 }
 
-function normalizedMergeSha(pullRequest) {
-    if (pullRequest && (pullRequest.mergeable === false || pullRequest.mergeable_state === 'dirty')) {
-        return 'none';
-    }
-    return pullRequest && SHA_PATTERN.test(String(pullRequest.merge_commit_sha || '')) ?
-        pullRequest.merge_commit_sha : 'none';
-}
-
 function pullRequestContext(pullRequest) {
     return Object.freeze({
         pullRequestNumber: requireInteger(pullRequest.number, 'pull request number'),
         headSha: requireSha(pullRequest.head && pullRequest.head.sha, 'pull request head SHA'),
         baseSha: requireSha(pullRequest.base && pullRequest.base.sha, 'pull request base SHA'),
-        mergeSha: requireMergeSha(normalizedMergeSha(pullRequest))
+        mergeSha: 'none'
     });
 }
 
@@ -700,8 +970,8 @@ function automaticBuildAllowed(pullRequest) {
 
 function mergeCommitMatchesContext(commit, context) {
     const parents = commit && Array.isArray(commit.parents) ? commit.parents.map((parent) => parent.sha) : [];
-    return parents.length === 2 && new Set(parents).size === 2 &&
-        parents.includes(context.baseSha) && parents.includes(context.headSha);
+    return commit && commit.sha === context.mergeSha && context.baseSha !== context.headSha &&
+        parents.length === 2 && parents[0] === context.baseSha && parents[1] === context.headSha;
 }
 
 function requireMergeRetry(options) {
@@ -719,9 +989,15 @@ async function waitForStablePullRequest({ api, pullRequestNumber, expectedHeadSh
         const context = pullRequestContext(pullRequest);
         if (expectedHeadSha && context.headSha !== expectedHeadSha ||
             expectedBaseSha && context.baseSha !== expectedBaseSha) {
-            throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: build context changed during reconciliation`);
+            throw new PrVsixInvariantError(
+                `pull request ${pullRequestNumber}: build context changed during reconciliation`,
+                { code: ERROR_CODE_CONTEXT_CHANGED }
+            );
         }
         if (pullRequest.state !== 'open') {
+            return Object.freeze({ pullRequest, context, buildable: false });
+        }
+        if (!automaticBuildAllowed(pullRequest)) {
             return Object.freeze({ pullRequest, context, buildable: false });
         }
         if (pullRequest.mergeable === false || pullRequest.mergeable_state === 'dirty') {
@@ -731,20 +1007,24 @@ async function waitForStablePullRequest({ api, pullRequestNumber, expectedHeadSh
                 buildable: false
             });
         }
-        if (pullRequest.mergeable === true && context.mergeSha !== 'none') {
-            const mergeCommit = await api.getCommit(context.mergeSha);
-            if (mergeCommitMatchesContext(mergeCommit, context)) {
-                return Object.freeze({ pullRequest, context, buildable: true });
+        const mergeSha = await api.getPullRequestMergeSha(pullRequestNumber);
+        if (mergeSha) {
+            const mergeContext = Object.freeze({ ...context, mergeSha });
+            const mergeCommit = await api.getCommit(mergeSha);
+            if (mergeCommitMatchesContext(mergeCommit, mergeContext)) {
+                return Object.freeze({ pullRequest, context: mergeContext, buildable: true });
             }
         }
         if (attempt < options.attempts) {
             await new Promise((resolve) => setTimeout(resolve, options.intervalMs));
         }
     }
-    throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: merge context did not stabilize`);
+    throw new PrVsixInvariantError(`pull request ${pullRequestNumber}: merge context did not stabilize`, {
+        code: ERROR_CODE_MERGE_UNSTABLE
+    });
 }
 
-function runMatchesPullRequest(run, pullRequest, repository) {
+function runMatchesPullRequest(run, pullRequest, repository, options = {}) {
     const context = pullRequestContext(pullRequest);
     const baseRepository = pullRequest.base && pullRequest.base.repo;
     const runCreatedAt = timestamp(run.createdAt, 'workflow run creation time');
@@ -755,9 +1035,11 @@ function runMatchesPullRequest(run, pullRequest, repository) {
     const sourceMatches = run.event === 'repository_dispatch' && baseRepository &&
         baseRepository.id === run.headRepositoryId;
 
+    const sourceContextMatches = context.headSha === run.headSha && context.baseSha === run.baseSha;
+
     return run.pullRequestNumber === pullRequest.number && baseRepository &&
         baseRepository.full_name === repository && sourceMatches && temporal &&
-        (closedRepair || contextMatches(context, run));
+        (closedRepair || options.allowSourceDrift || sourceContextMatches);
 }
 
 function ciRunFromRaw(rawRun) {
@@ -769,13 +1051,38 @@ function ciRunFromRaw(rawRun) {
     return Object.freeze({ ...workflowRun, ...context, source: 'ci' });
 }
 
-async function associatedPullRequest(api, workflowRun, repository) {
+async function associatedPullRequest(api, workflowRun, repository, mergeRetry, options = {}) {
     const context = parseCiRunName(workflowRun.displayTitle);
     if (!context) {
         throw new PrVsixInvariantError(`workflow run ${workflowRun.id}: missing canonical PR run name`);
     }
     const pullRequest = await api.getPullRequest(context.pullRequestNumber);
-    return runMatchesPullRequest({ ...workflowRun, ...context }, pullRequest, repository) ? pullRequest : undefined;
+    if (!runMatchesPullRequest(
+        { ...workflowRun, ...context },
+        pullRequest,
+        repository,
+        { allowSourceDrift: options.allowSourceDrift }
+    )) {
+        return undefined;
+    }
+    if (!options.skipMergeRef && context.mergeSha !== 'none' && pullRequest.state === 'open' &&
+        automaticBuildAllowed(pullRequest)) {
+        const stable = await waitForStablePullRequest({
+            api,
+            pullRequestNumber: context.pullRequestNumber,
+            expectedHeadSha: context.headSha,
+            expectedBaseSha: context.baseSha,
+            retry: mergeRetry
+        });
+        if (!stable.buildable || stable.context.mergeSha !== context.mergeSha) {
+            throw new PrVsixInvariantError(
+                `pull request ${context.pullRequestNumber}: merge context changed before publication`,
+                { code: ERROR_CODE_MERGE_CHANGED, canonicalMergeSha: stable.context.mergeSha }
+            );
+        }
+        return stable.pullRequest;
+    }
+    return pullRequest;
 }
 
 async function latestCiRun(api, workflow, pullRequest, repository, options = {}) {
@@ -789,6 +1096,7 @@ async function latestCiRun(api, workflow, pullRequest, repository, options = {})
     });
     const matching = runs.map(ciRunFromRaw).filter((run) =>
         run && (!options.actions || options.actions.has(run.action)) &&
+        (!options.expectedMergeSha || run.mergeSha === options.expectedMergeSha) &&
         runMatchesPullRequest(run, pullRequest, repository)
     );
     return matching.reduce((candidate, run) =>
@@ -809,11 +1117,26 @@ async function upsertComment(
         comment && comment.user && comment.user.login === BOT_LOGIN &&
         typeof comment.body === 'string' && comment.body.includes(COMMENT_MARKER)
     ).sort((left, right) => left.id - right.id);
-    if (managed.some((comment) => {
-        const metadata = parseCommentMetadata(comment.body);
-        return metadata && existingStateDominates(metadata, run);
-    })) {
-        return Object.freeze({ applied: false, removedArtifacts: 0 });
+    const managedStates = managed.map((comment) => Object.freeze({
+        comment,
+        metadata: parseCommentMetadata(comment.body)
+    }));
+    const dominant = managedStates.filter(({ metadata }) => metadata && existingStateDominates(metadata, run))
+        .sort((left, right) => compareCommentState(right.metadata, left.metadata))[0];
+    if (dominant) {
+        const duplicates = managedStates.filter((entry) => entry !== dominant);
+        await Promise.all(duplicates.map(async ({ comment }) => {
+            if (comment.body !== dominant.comment.body) {
+                await api.updateIssueComment(comment.id, dominant.comment.body);
+            }
+            await api.deleteIssueComment(comment.id);
+        }));
+        return Object.freeze({
+            applied: false,
+            removedArtifacts: 0,
+            retainedStates: [dominant.metadata],
+            replacedStates: duplicates.map(({ metadata }) => metadata).filter(Boolean)
+        });
     }
 
     const primary = managed[0];
@@ -829,12 +1152,59 @@ async function upsertComment(
             await api.updateIssueComment(primary.id, initialBody);
         }
     }
-    await Promise.all(managed.slice(primary ? 1 : 0).map((comment) => api.deleteIssueComment(comment.id)));
-    const removedArtifacts = await prepare();
+    const duplicates = managed.slice(primary ? 1 : 0);
+    await Promise.all(duplicates.map(async (comment) => {
+        if (comment.body !== initialBody) {
+            await api.updateIssueComment(comment.id, initialBody);
+        }
+        await api.deleteIssueComment(comment.id);
+    }));
+    const replacedStates = managedStates.map(({ metadata }) => metadata).filter(Boolean);
+    const removedArtifacts = await prepare(replacedStates);
     if (!alreadyFinal && transitionBody && transitionBody !== body) {
         await api.updateIssueComment(commentId, body);
     }
-    return Object.freeze({ applied: true, commentId, removedArtifacts });
+    return Object.freeze({
+        applied: true,
+        commentId,
+        removedArtifacts,
+        retainedStates: [],
+        replacedStates
+    });
+}
+
+async function reconcileNamespaceInvalidation({ api, pullRequestNumber, body, run }) {
+    let comment;
+    let commentError;
+    try {
+        comment = await upsertComment(api, pullRequestNumber, body, run);
+    } catch (error) {
+        commentError = error;
+    }
+    let removedArtifacts;
+    let cleanupError;
+    try {
+        removedArtifacts = await removePreviewArtifacts(api, pullRequestNumber);
+    } catch (error) {
+        cleanupError = error;
+    }
+    if (commentError && cleanupError) {
+        throw new AggregateError(
+            [commentError, cleanupError],
+            'PR VSIX comment and artifact invalidation failed'
+        );
+    }
+    if (commentError) {
+        throw commentError;
+    }
+    if (cleanupError) {
+        throw cleanupError;
+    }
+    return Object.freeze({
+        pullRequestNumber,
+        applied: comment.applied,
+        removedArtifacts
+    });
 }
 
 async function removePreviewArtifacts(api, pullRequestNumber, retainedArtifactId, retainedRun) {
@@ -857,8 +1227,44 @@ async function removePreviewArtifacts(api, pullRequestNumber, retainedArtifactId
             return timestamp(artifact.created_at, 'artifact creation time') <=
                 timestamp(retainedRun.updatedAt, 'workflow run update time');
         }
+        if (artifact.workflow_run && Number.isSafeInteger(artifact.workflow_run.id)) {
+            return artifact.workflow_run.id < retainedRun.id;
+        }
         return timestamp(artifact.created_at, 'artifact creation time') <
             timestamp(retainedRun.createdAt, 'workflow run creation time');
+    });
+    await Promise.all(removals.map((artifact) => api.deleteArtifact(artifact.id)));
+    return removals.length;
+}
+
+async function removeFailureArtifacts(
+    api,
+    pullRequestNumber,
+    observationRun,
+    retainedRun,
+    invalidatedArtifactIds = [],
+    retainedArtifactIds = []
+) {
+    const name = previewArtifactName(pullRequestNumber);
+    const artifacts = await api.listArtifactsByName(name);
+    const observationCreatedAt = timestamp(observationRun.createdAt, 'workflow run creation time');
+    const invalidatedIds = new Set(invalidatedArtifactIds);
+    const retainedIds = new Set(retainedArtifactIds);
+    const removals = artifacts.filter((artifact) => {
+        if (artifact.name !== name) {
+            throw new PrVsixInvariantError(`artifact ${artifact.id}: managed name mismatch`);
+        }
+        if (retainedIds.has(artifact.id) || retainedRun && isArtifactForRun(artifact, retainedRun, pullRequestNumber)) {
+            return false;
+        }
+        if (invalidatedIds.has(artifact.id)) {
+            return true;
+        }
+        if (artifact.workflow_run && artifact.workflow_run.id === observationRun.id &&
+            isArtifactForRun(artifact, observationRun, pullRequestNumber)) {
+            return true;
+        }
+        return timestamp(artifact.created_at, 'artifact creation time') < observationCreatedAt;
     });
     await Promise.all(removals.map((artifact) => api.deleteArtifact(artifact.id)));
     return removals.length;
@@ -868,6 +1274,14 @@ async function removeRunArtifacts(api, artifacts, run, pullRequestNumber) {
     const removals = artifacts.filter((artifact) => isArtifactForRun(artifact, run, pullRequestNumber));
     await Promise.all(removals.map((artifact) => api.deleteArtifact(artifact.id)));
     return removals.length;
+}
+
+async function removeCompletedRunArtifacts(api, run, action) {
+    if (action !== 'completed') {
+        return 0;
+    }
+    const artifacts = await api.listRunArtifacts(run.id);
+    return removeRunArtifacts(api, artifacts, run, run.pullRequestNumber);
 }
 
 async function synchronizeCompletedRun({ api, repository, run, pullRequest, artifacts, targets }) {
@@ -916,7 +1330,7 @@ async function synchronizeCompletedRun({ api, repository, run, pullRequest, arti
     });
 }
 
-async function synchronizeWorkflowRun({ api, repository, run, targets, action }) {
+async function synchronizeWorkflowRun({ api, repository, run, targets, action, mergeRetry }) {
     const identity = classifyWorkflowRun(run);
     if (identity.source !== 'ci') {
         throw new PrVsixInvariantError('PR VSIX build workflow run: unexpected workflow identity');
@@ -927,14 +1341,88 @@ async function synchronizeWorkflowRun({ api, repository, run, targets, action })
         return [];
     }
     const workflowRun = Object.freeze({ ...rawRun, ...context, source: 'ci' });
-    const pullRequest = await associatedPullRequest(api, rawRun, requireRepository(repository));
-    const artifacts = action === 'completed' ? await api.listRunArtifacts(workflowRun.id) : [];
-    if (!pullRequest) {
-        if (action === 'completed') {
-            await removeRunArtifacts(api, artifacts, workflowRun, workflowRun.pullRequestNumber);
+    const renewal = workflowRun.action === 'renewal';
+    const preservesRenewal = renewal &&
+        (action === 'in_progress' || action === 'completed' && workflowRun.conclusion !== 'success');
+    let pullRequest;
+    try {
+        pullRequest = await associatedPullRequest(
+            api,
+            rawRun,
+            requireRepository(repository),
+            mergeRetry,
+            {
+                skipMergeRef: preservesRenewal || workflowRun.action === 'approval-revoked',
+                allowSourceDrift: workflowRun.action === 'approval-revoked'
+            }
+        );
+    } catch (error) {
+        if (error && error.code === ERROR_CODE_CONTEXT_CHANGED) {
+            await removeCompletedRunArtifacts(api, workflowRun, action);
+            return [];
         }
+        if (renewal && (!error || error.code !== ERROR_CODE_MERGE_CHANGED)) {
+            throw error;
+        }
+        pullRequest = await publishSynchronizationFailure({
+            api,
+            repository,
+            run: workflowRun,
+            error,
+            retainedRun: error && error.code === ERROR_CODE_MERGE_CHANGED ? undefined : workflowRun,
+            onStale: () => removeCompletedRunArtifacts(api, workflowRun, action),
+            mergeRetry
+        });
+    }
+    if (!pullRequest) {
+        await removeCompletedRunArtifacts(api, workflowRun, action);
         return [];
     }
+
+    if (!['in_progress', 'completed'].includes(action)) {
+        throw new PrVsixInvariantError(`PR VSIX build workflow action: unsupported ${action}`);
+    }
+    const currentContext = pullRequestContext(pullRequest);
+    if (pullRequest.state === 'closed') {
+        const closedRun = Object.freeze({ ...workflowRun, ...currentContext, phase: 'closed' });
+        return [await reconcileNamespaceInvalidation({
+            api,
+            pullRequestNumber: pullRequest.number,
+            body: renderClosedComment({ repository, run: closedRun }),
+            run: closedRun
+        })];
+    }
+    if (pullRequest.state !== 'open' || workflowRun.action === 'closed-repair') {
+        return [];
+    }
+    if (workflowRun.action === 'approval-revoked' && automaticBuildAllowed(pullRequest)) {
+        return [];
+    }
+    if (!automaticBuildAllowed(pullRequest)) {
+        const blockedRun = Object.freeze({
+            ...workflowRun,
+            ...currentContext,
+            phase: 'blocked',
+            failureState: true,
+            invalidatesArtifact: true,
+            authorizationRevoked: true
+        });
+        return [await reconcileNamespaceInvalidation({
+            api,
+            pullRequestNumber: pullRequest.number,
+            body: renderUnavailableComment({
+                repository,
+                run: blockedRun,
+                reason: EXTERNAL_APPROVAL_REASON
+            }),
+            run: blockedRun
+        })];
+    }
+    if (workflowRun.action === 'renewal' && action === 'in_progress') {
+        return [];
+    }
+
+    const artifacts = action === 'completed' ? await api.listRunArtifacts(workflowRun.id) : [];
 
     const latest = await latestCiRun(
         api,
@@ -943,7 +1431,8 @@ async function synchronizeWorkflowRun({ api, repository, run, targets, action })
         repository,
         {
             createdAfter: workflowRun.createdAt,
-            omitHeadSha: workflowRun.action === 'closed-repair'
+            omitHeadSha: workflowRun.action === 'closed-repair',
+            expectedMergeSha: workflowRun.mergeSha
         }
     );
     const currentGeneration = latest && latest.id === workflowRun.id &&
@@ -955,57 +1444,9 @@ async function synchronizeWorkflowRun({ api, repository, run, targets, action })
         return [];
     }
 
-    if (pullRequest.state === 'closed') {
-        const closedRun = Object.freeze({ ...workflowRun, phase: 'closed' });
-        const comment = await upsertComment(
-            api,
-            pullRequest.number,
-            renderClosedComment({ repository, run: closedRun }),
-            closedRun,
-            () => removePreviewArtifacts(api, pullRequest.number)
-        );
-        return [Object.freeze({
-            pullRequestNumber: pullRequest.number,
-            applied: comment.applied,
-            removedArtifacts: comment.removedArtifacts
-        })];
-    }
-    if (pullRequest.state !== 'open') {
-        return [];
-    }
-    if (workflowRun.action === 'closed-repair' ||
-        (workflowRun.action === 'approval-revoked' && automaticBuildAllowed(pullRequest))) {
-        return [];
-    }
-    if (!['in_progress', 'completed'].includes(action)) {
-        throw new PrVsixInvariantError(`PR VSIX build workflow action: unsupported ${action}`);
-    }
-    if (!automaticBuildAllowed(pullRequest)) {
-        const blockedRun = Object.freeze({ ...workflowRun, phase: 'blocked' });
-        const comment = await upsertComment(
-            api,
-            pullRequest.number,
-            renderUnavailableComment({
-                repository,
-                run: blockedRun,
-                reason: EXTERNAL_APPROVAL_REASON
-            }),
-            blockedRun,
-            () => removePreviewArtifacts(api, pullRequest.number)
-        );
-        const removedArtifacts = comment.applied ? comment.removedArtifacts :
-            await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
-        return [Object.freeze({
-            pullRequestNumber: pullRequest.number,
-            applied: comment.applied,
-            removedArtifacts
-        })];
-    }
     if (workflowRun.action === 'renewal' &&
-        (action === 'in_progress' || action === 'completed' && workflowRun.conclusion !== 'success')) {
-        if (action === 'completed') {
-            await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
-        }
+        action === 'completed' && workflowRun.conclusion !== 'success') {
+        await removeRunArtifacts(api, artifacts, workflowRun, pullRequest.number);
         return [];
     }
     if (action === 'in_progress') {
@@ -1082,7 +1523,10 @@ async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRet
     if (expectedState === 'open') {
         current = current && pullRequest.base.sha === marker.baseSha;
     }
-    if (!current) {
+    const terminalOverride = baseRepositoryMatches &&
+        (pullRequest.state === 'closed' ||
+            pullRequest.state === 'open' && !automaticBuildAllowed(pullRequest));
+    if (!current && !terminalOverride) {
         await removeLifecycleMarkers(api, artifacts, workflowRun);
         return [];
     }
@@ -1112,25 +1556,27 @@ async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRet
                     retry: mergeRetry
                 });
             } catch (error) {
-                const provisionalRun = Object.freeze({
-                    ...workflowRun,
-                    ...context,
-                    action: ciAction,
-                    source: 'lifecycle',
-                    phase: 'pending'
-                });
-                await upsertComment(
+                if (error && error.code === ERROR_CODE_CONTEXT_CHANGED) {
+                    await removeLifecycleMarkers(api, artifacts, workflowRun);
+                    return [];
+                }
+                await publishSynchronizationFailure({
                     api,
-                    pullRequest.number,
-                    renderPendingComment({ repository, run: provisionalRun }),
-                    provisionalRun,
-                    () => removePreviewArtifacts(api, pullRequest.number)
-                );
-                throw error;
+                    repository,
+                    error,
+                    run: Object.freeze({
+                        ...workflowRun,
+                        ...context,
+                        action: ciAction,
+                        source: 'lifecycle'
+                    }),
+                    onStale: () => removeLifecycleMarkers(api, artifacts, workflowRun)
+                });
             }
             pullRequest = stable.pullRequest;
             context = stable.context;
             buildable = stable.buildable;
+            authorized = automaticBuildAllowed(pullRequest);
         }
     }
 
@@ -1140,7 +1586,11 @@ async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRet
             'pr-vsix-build.yml',
             pullRequest,
             repository,
-            { actions: new Set([ciAction]), createdAfter: workflowRun.createdAt }
+            {
+                actions: new Set([ciAction]),
+                createdAfter: workflowRun.createdAt,
+                expectedMergeSha: context.mergeSha
+            }
         );
         if (currentCi) {
             let result;
@@ -1174,7 +1624,7 @@ async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRet
         }
     }
 
-    const phase = expectedState === 'closed' ? 'closed' : !authorized || !buildable ? 'blocked' : 'pending';
+    const phase = pullRequest.state === 'closed' ? 'closed' : !authorized || !buildable ? 'blocked' : 'pending';
     const lifecycleRun = Object.freeze({
         ...workflowRun,
         ...context,
@@ -1192,13 +1642,19 @@ async function synchronizeLifecycleRun({ api, repository, run, targets, mergeRet
             run: lifecycleRun,
             reason: 'The pull request has merge conflicts; CI cannot produce a tested artifact.'
         }) : renderPendingComment({ repository, run: lifecycleRun });
-    const comment = await upsertComment(
-        api,
-        pullRequest.number,
-        body,
-        lifecycleRun,
-        () => removePreviewArtifacts(api, pullRequest.number)
-    );
+    const comment = phase === 'closed' || !authorized || !buildable ?
+        await reconcileNamespaceInvalidation({
+            api,
+            pullRequestNumber: pullRequest.number,
+            body,
+            run: lifecycleRun
+        }) : await upsertComment(
+            api,
+            pullRequest.number,
+            body,
+            lifecycleRun,
+            () => removePreviewArtifacts(api, pullRequest.number)
+        );
     if (expectedState === 'open' && authorized && buildable) {
         await api.dispatchRepositoryEvent('refresh-pr-vsix', {
             pull_request_number: context.pullRequestNumber,
@@ -1252,16 +1708,17 @@ async function main() {
         apiUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
         retry: apiRetryFromEnvironment()
     });
-    const mergeRetry = identity.source === 'lifecycle' ? requireMergeRetry({
+    const mergeRetry = requireMergeRetry({
         attempts: Number(process.env.PR_VSIX_MERGE_ATTEMPTS),
         intervalMs: Number(process.env.PR_VSIX_MERGE_INTERVAL_MS)
-    }) : undefined;
+    });
     const results = identity.source === 'ci' ? await synchronizeWorkflowRun({
         api,
         repository,
         run: event.workflow_run,
         targets,
-        action: event.action
+        action: event.action,
+        mergeRetry
     }) : await synchronizeLifecycleRun({
         api,
         repository,
@@ -1287,7 +1744,6 @@ export {
     automaticBuildAllowed,
     compareSequence,
     createGitHubApi,
-    normalizedMergeSha,
     parseCiRunName,
     parseCommentMetadata,
     previewArtifactName,

--- a/test/pr-vsix-comment.test.js
+++ b/test/pr-vsix-comment.test.js
@@ -13,6 +13,7 @@ var SHA_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 var SHA_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 var SHA_C = 'cccccccccccccccccccccccccccccccccccccccc';
 var SHA_D = 'dddddddddddddddddddddddddddddddddddddddd';
+var SHA_E = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 var TARGETS = require( '../scripts/release/targets.json' );
 
 function resolveWorkflowEvent( run )
@@ -81,7 +82,7 @@ function pullRequest( overrides )
         closed_at: null,
         mergeable: true,
         mergeable_state: 'clean',
-        merge_commit_sha: SHA_C,
+        merge_commit_sha: null,
         author_association: 'OWNER',
         labels: [],
         head: { sha: SHA_A, ref: 'fix/issue-19', repo: { id: 99 } },
@@ -134,7 +135,7 @@ function lifecycleArtifact( action, overrides )
     return Object.assign( {
         id: 600,
         name: 'better-todo-tree-pr-vsix-event-19-head-' + SHA_A + '-base-' + SHA_B +
-            '-merge-' + SHA_C + '-' + action + '-run-500-attempt-1',
+            '-merge-none-' + action + '-run-500-attempt-1',
         expired: false,
         size_in_bytes: 100,
         digest: 'sha256:' + 'f'.repeat( 64 ),
@@ -150,27 +151,71 @@ function apiFixture( options )
     var activeRun = workflowRun();
     var calls = {
         createdComments: [],
+        commitReads: [],
         updatedComments: [],
         deletedComments: [],
         deletedArtifacts: [],
         dispatchedEvents: [],
+        mergeRefReads: [],
+        pullRequestReads: [],
+        runArtifactReads: [],
         workflowQueries: [],
         order: []
     };
     var api = {
         getPullRequest: async function( number )
         {
+            calls.pullRequestReads.push( number );
+            if( settings.pullRequestError )
+            {
+                throw settings.pullRequestError;
+            }
+            if( Array.isArray( settings.pullRequestResponses ) )
+            {
+                var response = settings.pullRequestResponses[ Math.min(
+                    calls.pullRequestReads.length - 1,
+                    settings.pullRequestResponses.length - 1
+                ) ];
+                if( response instanceof Error )
+                {
+                    throw response;
+                }
+                return response;
+            }
             return ( settings.pullRequests || [ pullRequest() ] ).find( function( item )
             {
                 return item.number === number;
             } );
         },
-        getCommit: async function()
+        getPullRequestMergeSha: async function( number )
         {
-            return settings.mergeCommit || { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+            calls.mergeRefReads.push( number );
+            if( Array.isArray( settings.mergeRefShas ) )
+            {
+                return settings.mergeRefShas[ Math.min(
+                    calls.mergeRefReads.length - 1,
+                    settings.mergeRefShas.length - 1
+                ) ];
+            }
+            return Object.prototype.hasOwnProperty.call( settings, 'mergeRefSha' ) ?
+                settings.mergeRefSha : SHA_C;
+        },
+        getCommit: async function( sha )
+        {
+            calls.commitReads.push( sha );
+            if( settings.mergeCommitError )
+            {
+                throw settings.mergeCommitError;
+            }
+            return settings.mergeCommit || { sha: sha, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
         },
         listRunArtifacts: async function( runId )
         {
+            calls.runArtifactReads.push( runId );
+            if( settings.runArtifactsError )
+            {
+                throw settings.runArtifactsError;
+            }
             if( settings.runArtifactsByRun )
             {
                 return settings.runArtifactsByRun[ runId ] || [];
@@ -180,6 +225,10 @@ function apiFixture( options )
         listWorkflowRuns: async function( workflow, filters )
         {
             calls.workflowQueries.push( { workflow: workflow, filters: filters } );
+            if( settings.workflowRunsError )
+            {
+                throw settings.workflowRunsError;
+            }
             return ( settings.workflowRuns || [ activeRun ] ).filter( function( item )
             {
                 return ( !filters || !filters.createdAfter ||
@@ -217,11 +266,19 @@ function apiFixture( options )
         {
             calls.updatedComments.push( { id: id, body: body } );
             calls.order.push( 'update-comment-' + id );
+            if( settings.updateCommentError )
+            {
+                throw settings.updateCommentError;
+            }
             return { id: id };
         },
         deleteIssueComment: async function( id )
         {
             calls.deletedComments.push( id );
+            if( settings.deleteCommentError )
+            {
+                throw settings.deleteCommentError;
+            }
         },
         dispatchRepositoryEvent: async function( name, payload )
         {
@@ -236,7 +293,7 @@ function apiFixture( options )
     };
 }
 
-function synchronize( module, fixture, run, action )
+function synchronize( module, fixture, run, action, mergeRetry )
 {
     fixture.setActiveRun( run );
     return module.synchronizeWorkflowRun( {
@@ -244,7 +301,8 @@ function synchronize( module, fixture, run, action )
         repository: REPOSITORY,
         run: run,
         targets: TARGETS,
-        action: action || 'completed'
+        action: action || 'completed',
+        mergeRetry: mergeRetry || { attempts: 1, intervalMs: 0 }
     } );
 }
 
@@ -309,6 +367,24 @@ QUnit.test( 'successful current run publishes one raw VSIX link and removes dupl
     assert.ok( body.indexOf( '`win32-x64`' ) !== -1 );
     assert.ok( body.indexOf( '`web`' ) === -1 );
     assert.ok( body.indexOf( 'unreviewed code from this pull request' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+} );
+
+QUnit.test( 'successful cleanup removes a late artifact from an older workflow run', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var lateOld = artifact( {
+        id: 299,
+        created_at: '2026-07-11T10:05:30Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var fixture = apiFixture( {
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, lateOld ]
+    } );
+
+    assert.equal( ( await synchronize( module, fixture, workflowRun() ) )[ 0 ].applied, true );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
 } );
 
@@ -560,7 +636,8 @@ QUnit.test( 'superseded rerun attempt deletes its exact attempt artifact', async
         repository: REPOSITORY,
         run: oldRun,
         targets: TARGETS,
-        action: 'completed'
+        action: 'completed',
+        mergeRetry: { attempts: 1, intervalMs: 0 }
     } ), [] );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
 } );
@@ -586,7 +663,8 @@ QUnit.test( 'superseded attempt callback cannot delete the newer attempt artifac
         repository: REPOSITORY,
         run: oldRun,
         targets: TARGETS,
-        action: 'completed'
+        action: 'completed',
+        mergeRetry: { attempts: 1, intervalMs: 0 }
     } ), [] );
     assert.deepEqual( fixture.calls.deletedArtifacts, [] );
 } );
@@ -614,7 +692,8 @@ QUnit.test( 'superseded same-SHA workflow generation deletes its artifact', asyn
         repository: REPOSITORY,
         run: oldRun,
         targets: TARGETS,
-        action: 'completed'
+        action: 'completed',
+        mergeRetry: { attempts: 1, intervalMs: 0 }
     } ), [] );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
 } );
@@ -633,7 +712,649 @@ QUnit.test( 'repository dispatch run validates immutable PR context', async func
     var fixture = apiFixture( { runArtifacts: [ current ], repositoryArtifacts: [ current ] } );
 
     assert.equal( ( await synchronize( module, fixture, run ) )[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.commitReads, [ SHA_C ] );
     assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: ready' ) !== -1 );
+} );
+
+QUnit.test( 'repository dispatch callback retries a transient missing merge ref', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact( { workflow_run: { id: 200, head_sha: SHA_B } } );
+    var fixture = apiFixture( {
+        mergeRefShas: [ undefined, SHA_C ],
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    assert.equal( ( await synchronize(
+        module,
+        fixture,
+        workflowRun(),
+        'completed',
+        { attempts: 2, intervalMs: 0 }
+    ) )[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.mergeRefReads, [ 19, 19 ] );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: ready' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'repository dispatch ref exhaustion preserves its artifact for callback retry', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun();
+    var current = artifact( { workflow_run: { id: 200, head_sha: SHA_B } } );
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var fixture = apiFixture( {
+        mergeRefSha: undefined,
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current, prior ],
+        comments: [ {
+            id: 401,
+            body: module.renderPendingComment( {
+                repository: REPOSITORY,
+                run: commentRun( module, run, 'pending' )
+            } ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, run ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+
+    fixture.settings.mergeRefSha = SHA_C;
+    fixture.settings.repositoryArtifacts = [ current ];
+    fixture.settings.comments = [ {
+        id: 401,
+        body: fixture.calls.updatedComments[ 0 ].body,
+        user: { login: 'github-actions[bot]' }
+    } ];
+    assert.equal( ( await synchronize( module, fixture, run ) )[ 0 ].applied, true );
+    assert.ok( fixture.calls.updatedComments[ fixture.calls.updatedComments.length - 1 ].body
+        .indexOf( 'PR VSIX: ready' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+} );
+
+QUnit.test( 'delayed callback failure preserves a newer ready rerun', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun();
+    var oldArtifact = artifact();
+    var newerRun = workflowRun( {
+        run_attempt: 2,
+        run_started_at: '2026-07-11T11:00:00Z',
+        updated_at: '2026-07-11T11:06:00Z'
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T11:05:00Z'
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        mergeCommitError: apiError,
+        repositoryArtifacts: [ oldArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, oldRun ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'terminal callback failure blocks a delayed pending callback', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun();
+    var fixture = apiFixture( { mergeRefSha: undefined } );
+
+    await assert.rejects( synchronize( module, fixture, run ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    var unavailableBody = fixture.calls.createdComments[ 0 ].body;
+    assert.ok( unavailableBody.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+
+    fixture.settings.comments = [ {
+        id: 401,
+        body: unavailableBody,
+        user: { login: 'github-actions[bot]' }
+    } ];
+    fixture.settings.mergeRefSha = SHA_C;
+    run.status = 'in_progress';
+    run.conclusion = null;
+    assert.equal( ( await synchronize( module, fixture, run, 'in_progress' ) )[ 0 ].applied, false );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, unavailableBody );
+} );
+
+QUnit.test( 'repository dispatch callback rejects a rotated merge ref', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact( { workflow_run: { id: 200, head_sha: SHA_B } } );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.equal( fixture.calls.createdComments.length, 1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf(
+        'The pull request merge ref changed before preview publication.'
+    ) !== -1 );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.commitReads, [ SHA_D, SHA_D ] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'rotated merge replay removes its previously ready link before cleanup', async function( assert )
+{
+    var module = await modulePromise;
+    var run = workflowRun();
+    var current = artifact( { workflow_run: { id: 200, head_sha: SHA_B } } );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, run, current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, run ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+    assert.deepEqual( fixture.calls.order, [ 'update-comment-401', 'delete-artifact-300' ] );
+} );
+
+QUnit.test( 'rotated merge failure cannot overwrite a concurrently newer source', async function( assert )
+{
+    var module = await modulePromise;
+    var staleRun = workflowRun();
+    var staleArtifact = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, merge: SHA_E } )
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        pullRequestResponses: [
+            pullRequest(),
+            pullRequest(),
+            pullRequest( { head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } } } )
+        ],
+        runArtifacts: [ staleArtifact ],
+        repositoryArtifacts: [ staleArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, staleRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'rotated merge failure preserves a newer same-source merge generation', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        run_started_at: '2026-07-11T10:20:00Z',
+        updated_at: '2026-07-11T10:26:00Z'
+    } );
+    var oldArtifact = artifact( {
+        created_at: '2026-07-11T10:25:00Z'
+    } );
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 21,
+        created_at: '2026-07-11T10:05:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { merge: SHA_D } )
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ oldArtifact ],
+        repositoryArtifacts: [ oldArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, oldRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'rotated merge failure invalidates a newer run for the obsolete merge', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun();
+    var oldArtifact = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 21,
+        created_at: '2026-07-11T10:05:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z'
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ oldArtifact ],
+        repositoryArtifacts: [ oldArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, newerRun, newerArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, oldRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300, 301 ] );
+    assert.deepEqual( fixture.calls.order, [
+        'update-comment-401',
+        'delete-artifact-300',
+        'delete-artifact-301'
+    ] );
+} );
+
+QUnit.test( 'rotated merge failure retains an older artifact for the canonical merge', async function( assert )
+{
+    var module = await modulePromise;
+    var failedRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:00:00Z',
+        run_started_at: '2026-07-11T10:00:00Z',
+        updated_at: '2026-07-11T10:06:00Z'
+    } );
+    var failedArtifact = artifact( {
+        id: 301,
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var canonicalRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z',
+        display_title: ciTitle( { merge: SHA_D } )
+    } );
+    var canonicalArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var canonicalBody = renderedReadyComment( module, canonicalRun, canonicalArtifact );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ failedArtifact ],
+        repositoryArtifacts: [ canonicalArtifact, failedArtifact ],
+        comments: [ {
+            id: 401,
+            body: canonicalBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, failedRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, canonicalBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 301 ] );
+} );
+
+QUnit.test( 'canonical ready duplicate outranks a pending comment', async function( assert )
+{
+    var module = await modulePromise;
+    var failedRun = workflowRun();
+    var failedArtifact = artifact();
+    var canonicalRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { merge: SHA_D } )
+    } );
+    var canonicalArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var canonicalCommentRun = commentRun( module, canonicalRun );
+    var readyBody = renderedReadyComment( module, canonicalRun, canonicalArtifact );
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ failedArtifact ],
+        repositoryArtifacts: [ failedArtifact, canonicalArtifact ],
+        comments: [ {
+            id: 401,
+            body: module.renderPendingComment( {
+                repository: REPOSITORY,
+                run: Object.assign( {}, canonicalCommentRun, { phase: 'pending' } )
+            } ),
+            user: { login: 'github-actions[bot]' }
+        }, {
+            id: 402,
+            body: readyBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, failedRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.updatedComments, [ { id: 401, body: readyBody } ] );
+    assert.deepEqual( fixture.calls.deletedComments, [ 401 ] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'merge ref revalidation follows a second rotation', async function( assert )
+{
+    var module = await modulePromise;
+    var failedArtifact = artifact();
+    var canonicalRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { merge: SHA_E } )
+    } );
+    var canonicalArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var canonicalBody = renderedReadyComment( module, canonicalRun, canonicalArtifact );
+    var fixture = apiFixture( {
+        mergeRefShas: [ SHA_D, SHA_E ],
+        runArtifacts: [ failedArtifact ],
+        repositoryArtifacts: [ failedArtifact, canonicalArtifact ],
+        comments: [ {
+            id: 401,
+            body: canonicalBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.canonicalMergeSha === SHA_E;
+    } );
+    assert.deepEqual( fixture.calls.mergeRefReads, [ 19, 19 ] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, canonicalBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'merge ref ABA revalidation resumes the original build callback', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var fixture = apiFixture( {
+        mergeRefShas: [ SHA_D, SHA_C ],
+        runArtifacts: [ current ],
+        repositoryArtifacts: [ current ]
+    } );
+
+    var result = await synchronize( module, fixture, workflowRun() );
+    assert.equal( result[ 0 ].applied, true );
+    assert.deepEqual( fixture.calls.mergeRefReads, [ 19, 19 ] );
+    assert.equal( fixture.calls.createdComments.length, 1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'PR VSIX: preparing' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: ready' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'repository dispatch source drift cannot replace newer ready state', async function( assert )
+{
+    var module = await modulePromise;
+    var staleRun = workflowRun();
+    var staleArtifact = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, merge: SHA_D } )
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var fixture = apiFixture( {
+        pullRequestResponses: [
+            pullRequest(),
+            pullRequest( { head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } } } )
+        ],
+        runArtifacts: [ staleArtifact ],
+        repositoryArtifacts: [ staleArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    assert.deepEqual( await synchronize( module, fixture, staleRun ), [] );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'unassociated API failure cannot mutate a newer source generation', async function( assert )
+{
+    var module = await modulePromise;
+    var staleRun = workflowRun();
+    var staleArtifact = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, merge: SHA_E } )
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/pulls/19: HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        pullRequestResponses: [
+            apiError,
+            pullRequest( { head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } } } )
+        ],
+        runArtifacts: [ staleArtifact ],
+        repositoryArtifacts: [ staleArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, staleRun ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+} );
+
+QUnit.test( 'revalidated source can replace a later stale context after a force-push reversal', async function( assert )
+{
+    var module = await modulePromise;
+    var currentRun = workflowRun();
+    var staleRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, merge: SHA_E } )
+    } );
+    var staleArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var staleBody = renderedReadyComment( module, staleRun, staleArtifact );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        mergeCommitError: apiError,
+        repositoryArtifacts: [ staleArtifact ],
+        comments: [ {
+            id: 401,
+            body: staleBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, currentRun ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( SHA_A.slice( 0, 12 ) ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 301 ] );
+} );
+
+QUnit.test( 'merge context requires exact commit identity and ordered parents', async function( assert )
+{
+    var module = await modulePromise;
+    var invalidCommits = [
+        { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        { sha: SHA_C, parents: [ { sha: SHA_A }, { sha: SHA_B } ] }
+    ];
+
+    for( var index = 0; index < invalidCommits.length; index++ )
+    {
+        var fixture = apiFixture( { mergeCommit: invalidCommits[ index ] } );
+        await assert.rejects( module.waitForStablePullRequest( {
+            api: fixture.api,
+            pullRequestNumber: 19,
+            expectedHeadSha: SHA_A,
+            expectedBaseSha: SHA_B,
+            retry: { attempts: 1, intervalMs: 0 }
+        } ), function( error )
+        {
+            return error instanceof module.PrVsixInvariantError &&
+                error.message === 'pull request 19: merge context did not stabilize';
+        } );
+    }
 } );
 
 QUnit.test( 'metadata-only CI edit is ignored without artifact mutation', async function( assert )
@@ -673,10 +1394,130 @@ QUnit.test( 'renewal preserves the valid artifact through pending and failed bui
         repository: REPOSITORY,
         run: run,
         targets: TARGETS,
-        action: 'completed'
+        action: 'completed',
+        mergeRetry: { attempts: 1, intervalMs: 0 }
     } ), [] );
     assert.deepEqual( fixture.calls.updatedComments, [] );
     assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'renewal association failure preserves the last verified preview', async function( assert )
+{
+    var module = await modulePromise;
+    var current = artifact();
+    var run = workflowRun( {
+        display_title: ciTitle( { action: 'renewal' } ),
+        status: 'in_progress',
+        conclusion: null
+    } );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/pulls/19: HTTP 502: upstream failure'
+    );
+    var readyBody = renderedReadyComment( module, workflowRun(), current );
+    var fixture = apiFixture( {
+        pullRequestError: apiError,
+        repositoryArtifacts: [ current ],
+        comments: [ {
+            id: 401,
+            body: readyBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, run, 'in_progress' ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, readyBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+    assert.deepEqual( fixture.calls.mergeRefReads, [] );
+} );
+
+QUnit.test( 'successful renewal association failure preserves both preview generations', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var oldArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var renewalRun = workflowRun( {
+        display_title: ciTitle( { action: 'renewal' } )
+    } );
+    var renewalArtifact = artifact();
+    var readyBody = renderedReadyComment( module, oldRun, oldArtifact );
+    var fixture = apiFixture( {
+        mergeRefSha: undefined,
+        runArtifacts: [ renewalArtifact ],
+        repositoryArtifacts: [ oldArtifact, renewalArtifact ],
+        comments: [ {
+            id: 401,
+            body: readyBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, renewalRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, readyBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'successful renewal invalidates artifacts for a rotated merge ref', async function( assert )
+{
+    var module = await modulePromise;
+    var oldRun = workflowRun( {
+        id: 199,
+        run_number: 19,
+        created_at: '2026-07-11T09:50:00Z',
+        run_started_at: '2026-07-11T09:50:00Z',
+        updated_at: '2026-07-11T09:56:00Z'
+    } );
+    var oldArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var renewalRun = workflowRun( {
+        display_title: ciTitle( { action: 'renewal' } )
+    } );
+    var renewalArtifact = artifact();
+    var fixture = apiFixture( {
+        mergeRefSha: SHA_D,
+        mergeCommit: { sha: SHA_D, parents: [ { sha: SHA_B }, { sha: SHA_A } ] },
+        runArtifacts: [ renewalArtifact ],
+        repositoryArtifacts: [ oldArtifact, renewalArtifact ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, oldRun, oldArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, renewalRun ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context changed before publication';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 300 ] );
 } );
 
 QUnit.test( 'publisher revokes a fork artifact when approval changes during the build', async function( assert )
@@ -698,17 +1539,217 @@ QUnit.test( 'publisher revokes a fork artifact when approval changes during the 
     assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'safe-to-test' ) !== -1 );
     assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
+    assert.deepEqual( fixture.calls.mergeRefReads, [] );
+} );
+
+QUnit.test( 'failure revalidation revokes external fork artifact access', async function( assert )
+{
+    var module = await modulePromise;
+    var allowed = pullRequest( {
+        author_association: 'NONE',
+        labels: [ { name: 'safe-to-test' } ],
+        head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+    } );
+    var revoked = pullRequest( {
+        author_association: 'NONE',
+        labels: [],
+        head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+    } );
+    var current = artifact();
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var newer = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        pullRequestResponses: [ allowed, allowed, revoked ],
+        mergeCommitError: apiError,
+        repositoryArtifacts: [ current, prior, newer ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.equal( fixture.calls.createdComments.length, 1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'safe-to-test' ) !== -1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( '/artifacts/' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts.sort(), [ 299, 300, 301 ] );
+} );
+
+QUnit.test( 'authorization revocation overrides concurrent source drift and ready state', async function( assert )
+{
+    var module = await modulePromise;
+    var allowed = pullRequest( {
+        author_association: 'NONE',
+        labels: [ { name: 'safe-to-test' } ],
+        head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+    } );
+    var revoked = pullRequest( {
+        author_association: 'NONE',
+        labels: [],
+        head: { sha: SHA_D, ref: 'fork/issue-19', repo: { id: 2 } },
+        base: {
+            sha: SHA_E,
+            ref: 'master',
+            repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+        }
+    } );
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var current = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        head_sha: SHA_E,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, base: SHA_E } )
+    } );
+    var newer = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_E }
+    } );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        pullRequestResponses: [ allowed, allowed, revoked ],
+        mergeCommitError: apiError,
+        repositoryArtifacts: [ prior, current, newer ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, newerRun, newer ),
+            user: { login: 'github-actions[bot]' }
+        }, {
+            id: 402,
+            body: renderedReadyComment( module, newerRun, newer ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 2 );
+    var body = fixture.calls.updatedComments[ 0 ].body;
+    var metadata = module.parseCommentMetadata( body );
+    assert.ok( body.indexOf( 'safe-to-test' ) !== -1 );
+    assert.ok( body.indexOf( '/artifacts/' ) === -1 );
+    assert.ok( body.indexOf( '/commit/' + SHA_D ) !== -1 );
+    assert.ok( body.indexOf( '/commit/' + SHA_A ) === -1 );
+    assert.equal( metadata.headSha, SHA_D );
+    assert.equal( metadata.baseSha, SHA_E );
+    assert.equal( metadata.mergeSha, 'none' );
+    assert.equal( metadata.phase, 'blocked' );
+    assert.equal( metadata.artifactId, undefined );
+    assert.deepEqual( fixture.calls.deletedComments, [ 402 ] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 300, 301 ] );
+    assert.deepEqual( fixture.calls.order, [
+        'update-comment-401',
+        'update-comment-402',
+        'delete-artifact-299',
+        'delete-artifact-300',
+        'delete-artifact-301'
+    ] );
+} );
+
+QUnit.test( 'failure revalidation closes the current preview namespace', async function( assert )
+{
+    var module = await modulePromise;
+    var closed = pullRequest( {
+        state: 'closed',
+        closed_at: '2026-07-11T10:20:00Z',
+        head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } },
+        base: {
+            sha: SHA_E,
+            ref: 'master',
+            repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+        }
+    } );
+    var prior = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var current = artifact();
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        head_sha: SHA_E,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, base: SHA_E } )
+    } );
+    var newer = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_E }
+    } );
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        pullRequestResponses: [ pullRequest(), pullRequest(), closed ],
+        mergeCommitError: apiError,
+        repositoryArtifacts: [ prior, current, newer ],
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, newerRun, newer ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    var body = fixture.calls.updatedComments[ 0 ].body;
+    var metadata = module.parseCommentMetadata( body );
+    assert.ok( body.indexOf( 'removed when the pull request closed' ) !== -1 );
+    assert.ok( body.indexOf( '/artifacts/' ) === -1 );
+    assert.equal( metadata.headSha, SHA_D );
+    assert.equal( metadata.baseSha, SHA_E );
+    assert.equal( metadata.mergeSha, 'none' );
+    assert.equal( metadata.phase, 'closed' );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 300, 301 ] );
 } );
 
 QUnit.test( 'stale cleanup completion preserves state after authorization reversal', async function( assert )
 {
     var module = await modulePromise;
     var current = artifact();
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
     var cleanupRun = workflowRun( {
         display_title: ciTitle( { action: 'approval-revoked' } ),
         conclusion: 'failure'
     } );
     var fixture = apiFixture( {
+        mergeCommitError: apiError,
         repositoryArtifacts: [ current ],
         comments: [ {
             id: 401,
@@ -720,6 +1761,91 @@ QUnit.test( 'stale cleanup completion preserves state after authorization revers
     assert.deepEqual( await synchronize( module, fixture, cleanupRun ), [] );
     assert.deepEqual( fixture.calls.updatedComments, [] );
     assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+    assert.deepEqual( fixture.calls.mergeRefReads, [] );
+    assert.deepEqual( fixture.calls.commitReads, [] );
+} );
+
+QUnit.test( 'stale approval revocation cleans the current unauthorized source', async function( assert )
+{
+    var module = await modulePromise;
+    var revoked = pullRequest( {
+        author_association: 'NONE',
+        labels: [],
+        head: { sha: SHA_D, ref: 'fork/issue-19', repo: { id: 2 } },
+        base: {
+            sha: SHA_E,
+            ref: 'master',
+            repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+        }
+    } );
+    var oldArtifact = artifact();
+    var currentRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        head_sha: SHA_E,
+        created_at: '2026-07-11T10:10:00Z',
+        run_started_at: '2026-07-11T10:10:00Z',
+        updated_at: '2026-07-11T10:16:00Z',
+        display_title: ciTitle( { head: SHA_D, base: SHA_E } )
+    } );
+    var currentArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:15:00Z',
+        workflow_run: { id: 202, head_sha: SHA_E }
+    } );
+    var cleanupRun = workflowRun( {
+        display_title: ciTitle( { action: 'approval-revoked' } )
+    } );
+    var fixture = apiFixture( {
+        pullRequests: [ revoked ],
+        repositoryArtifacts: [ oldArtifact, currentArtifact ],
+        runArtifactsError: new Error( 'run artifacts must not be read' ),
+        workflowRunsError: new Error( 'workflow runs must not be read' ),
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, currentRun, currentArtifact ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    var result = await synchronize( module, fixture, cleanupRun );
+    assert.equal( result[ 0 ].applied, true );
+    var metadata = module.parseCommentMetadata( fixture.calls.updatedComments[ 0 ].body );
+    assert.equal( metadata.headSha, SHA_D );
+    assert.equal( metadata.baseSha, SHA_E );
+    assert.equal( metadata.mergeSha, 'none' );
+    assert.equal( metadata.phase, 'blocked' );
+    assert.deepEqual( fixture.calls.runArtifactReads, [] );
+    assert.deepEqual( fixture.calls.workflowQueries, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300, 301 ] );
+} );
+
+QUnit.test( 'authorization cleanup deletes artifacts after comment API failure', async function( assert )
+{
+    var module = await modulePromise;
+    var revoked = pullRequest( {
+        author_association: 'NONE',
+        labels: [],
+        head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+    } );
+    var current = artifact();
+    var commentError = new Error( 'comment update failed' );
+    var fixture = apiFixture( {
+        pullRequests: [ revoked ],
+        repositoryArtifacts: [ current ],
+        updateCommentError: commentError,
+        comments: [ {
+            id: 401,
+            body: renderedReadyComment( module, workflowRun(), current ),
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronize( module, fixture, workflowRun() ), function( error )
+    {
+        return error === commentError;
+    } );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 300 ] );
 } );
 
 QUnit.test( 'base-push conflict invalidates the previous merge artifact', async function( assert )
@@ -761,6 +1887,7 @@ QUnit.test( 'base-push conflict invalidates the previous merge artifact', async 
     assert.equal( ( await synchronize( module, fixture, run, 'in_progress' ) )[ 0 ].applied, true );
     assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+    assert.deepEqual( fixture.calls.mergeRefReads, [] );
 } );
 
 QUnit.test( 'trusted lifecycle marker posts building state and removes the prior slot', async function( assert )
@@ -779,6 +1906,182 @@ QUnit.test( 'trusted lifecycle marker posts building state and removes the prior
     ] );
     assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 600 ] );
+} );
+
+QUnit.test( 'merge ref exhaustion replaces building state and retains retry identity', async function( assert )
+{
+    var module = await modulePromise;
+    var pendingBody = module.renderPendingComment( {
+        repository: REPOSITORY,
+        run: {
+            id: 500,
+            runAttempt: 1,
+            runNumber: 50,
+            startedAt: '2026-07-11T10:00:01Z',
+            headSha: SHA_A,
+            baseSha: SHA_B,
+            mergeSha: 'none',
+            pullRequestNumber: 19,
+            action: 'synchronize',
+            source: 'lifecycle',
+            phase: 'pending',
+            conclusion: 'success'
+        }
+    } );
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ lifecycleArtifact( 'synchronize' ) ],
+        mergeRefSha: undefined,
+        repositoryArtifacts: [ artifact( {
+            id: 299,
+            created_at: '2026-07-11T09:55:00Z',
+            workflow_run: { id: 199, head_sha: SHA_B }
+        } ) ],
+        comments: [ {
+            id: 401,
+            body: pendingBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronizeLifecycle( module, fixture, lifecycleRun() ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.equal( fixture.calls.updatedComments.length, 1 );
+    assert.equal( fixture.calls.updatedComments[ 0 ].id, 401 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: unavailable' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'immutable merge ref' ) !== -1 );
+    assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'PR VSIX: building' ) === -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
+
+    fixture.settings.mergeRefSha = SHA_C;
+    fixture.settings.repositoryArtifacts = [];
+    fixture.settings.comments = [ {
+        id: 401,
+        body: fixture.calls.updatedComments[ 0 ].body,
+        user: { login: 'github-actions[bot]' }
+    } ];
+    assert.deepEqual( await synchronizeLifecycle( module, fixture, lifecycleRun() ), [
+        { pullRequestNumber: 19, applied: true, removedArtifacts: 0 }
+    ] );
+    assert.equal( fixture.calls.dispatchedEvents.length, 1 );
+    assert.ok( fixture.calls.updatedComments[ 1 ].body.indexOf( 'PR VSIX: building' ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299, 600 ] );
+} );
+
+QUnit.test( 'lifecycle source drift removes only the stale retry marker', async function( assert )
+{
+    var module = await modulePromise;
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ lifecycleArtifact( 'synchronize' ) ],
+        pullRequestResponses: [
+            pullRequest(),
+            pullRequest( { head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } } } )
+        ]
+    } );
+
+    assert.deepEqual( await synchronizeLifecycle( module, fixture, lifecycleRun() ), [] );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.dispatchedEvents, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600 ] );
+} );
+
+QUnit.test( 'lifecycle revalidation drift removes its stale retry marker without comment mutation', async function( assert )
+{
+    var module = await modulePromise;
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ lifecycleArtifact( 'synchronize' ) ],
+        mergeRefSha: undefined,
+        pullRequestResponses: [
+            pullRequest(),
+            pullRequest(),
+            pullRequest( { head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } } } )
+        ]
+    } );
+
+    await assert.rejects( synchronizeLifecycle( module, fixture, lifecycleRun() ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.deepEqual( fixture.calls.dispatchedEvents, [] );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 600 ] );
+} );
+
+QUnit.test( 'lifecycle API failure reports its own terminal reason and remains retryable', async function( assert )
+{
+    var module = await modulePromise;
+    var apiError = new module.PrVsixInvariantError(
+        'GitHub API GET /repos/FanaticPythoner/better-todo-tree/commits/' + SHA_C +
+        ': HTTP 502: upstream failure'
+    );
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ lifecycleArtifact( 'synchronize' ) ],
+        mergeCommitError: apiError
+    } );
+
+    await assert.rejects( synchronizeLifecycle( module, fixture, lifecycleRun() ), function( error )
+    {
+        return error === apiError;
+    } );
+    assert.equal( fixture.calls.createdComments.length, 1 );
+    assert.ok( fixture.calls.createdComments[ 0 ].body.indexOf(
+        'GitHub API access failed during preview reconciliation.'
+    ) !== -1 );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [] );
+} );
+
+QUnit.test( 'delayed lifecycle failure preserves newer ready state and artifact', async function( assert )
+{
+    var module = await modulePromise;
+    var newerRun = workflowRun( {
+        id: 202,
+        run_number: 22,
+        created_at: '2026-07-11T10:01:00Z',
+        run_started_at: '2026-07-11T10:01:00Z',
+        updated_at: '2026-07-11T10:06:00Z'
+    } );
+    var newerArtifact = artifact( {
+        id: 301,
+        created_at: '2026-07-11T10:05:00Z',
+        workflow_run: { id: 202, head_sha: SHA_B }
+    } );
+    var staleArtifact = artifact( {
+        id: 299,
+        created_at: '2026-07-11T09:55:00Z',
+        workflow_run: { id: 199, head_sha: SHA_B }
+    } );
+    var newerBody = renderedReadyComment( module, newerRun, newerArtifact );
+    var fixture = apiFixture( {
+        workflowRuns: [],
+        runArtifacts: [ lifecycleArtifact( 'synchronize' ) ],
+        mergeRefSha: undefined,
+        repositoryArtifacts: [ staleArtifact, newerArtifact ],
+        comments: [ {
+            id: 401,
+            body: newerBody,
+            user: { login: 'github-actions[bot]' }
+        } ]
+    } );
+
+    await assert.rejects( synchronizeLifecycle( module, fixture, lifecycleRun() ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request 19: merge context did not stabilize';
+    } );
+    assert.deepEqual( fixture.calls.createdComments, [] );
+    assert.deepEqual( fixture.calls.updatedComments, [] );
+    assert.equal( fixture.settings.comments[ 0 ].body, newerBody );
+    assert.deepEqual( fixture.calls.deletedArtifacts, [ 299 ] );
 } );
 
 QUnit.test( 'target and fallback lifecycle callbacks converge on one build generation', async function( assert )
@@ -942,7 +2245,12 @@ QUnit.test( 'safe-to-test removal revokes external preview access without rebuil
     var fixture = apiFixture( {
         pullRequests: [ pullRequest( {
             author_association: 'NONE',
-            head: { sha: SHA_A, ref: 'fork/issue-19', repo: { id: 2 } }
+            head: { sha: SHA_D, ref: 'fork/issue-19', repo: { id: 2 } },
+            base: {
+                sha: SHA_E,
+                ref: 'master',
+                repo: { id: 1, full_name: REPOSITORY, default_branch: 'master' }
+            }
         } ) ],
         runArtifacts: [ marker ],
         repositoryArtifacts: [ current ],
@@ -957,6 +2265,9 @@ QUnit.test( 'safe-to-test removal revokes external preview access without rebuil
         display_title: 'PR VSIX Event #19 unlabeled'
     } ) ) )[ 0 ].applied, true );
     assert.ok( fixture.calls.updatedComments[ 0 ].body.indexOf( 'safe-to-test' ) !== -1 );
+    var metadata = module.parseCommentMetadata( fixture.calls.updatedComments[ 0 ].body );
+    assert.equal( metadata.headSha, SHA_D );
+    assert.equal( metadata.baseSha, SHA_E );
     assert.deepEqual( fixture.calls.deletedArtifacts, [ 300, 600 ] );
     assert.deepEqual( fixture.calls.dispatchedEvents, [] );
 } );
@@ -1024,6 +2335,7 @@ QUnit.test( 'closed lifecycle marker ignores later base movement and removes the
             state: 'closed',
             closed_at: '2026-07-11T10:01:00Z',
             merge_commit_sha: SHA_D,
+            head: { sha: SHA_D, ref: 'fix/issue-19', repo: { id: 99 } },
             base: {
                 sha: SHA_D,
                 ref: 'master',
@@ -1234,6 +2546,64 @@ QUnit.test( 'GitHub API adapter paginates and dispatches refresh events', async 
     assert.equal( requests[ 0 ].options.headers.Authorization, 'Bearer token' );
     assert.equal( requests[ 0 ].options.headers[ 'X-GitHub-Api-Version' ], '2026-03-10' );
     assert.equal( JSON.parse( requests[ 2 ].options.body ).event_type, 'refresh-pr-vsix' );
+} );
+
+QUnit.test( 'GitHub API adapter resolves the versioned pull request merge ref', async function( assert )
+{
+    var module = await modulePromise;
+    var requests = [];
+    var responses = [
+        new Response( JSON.stringify( {
+            ref: 'refs/pull/19/merge',
+            object: { type: 'commit', sha: SHA_C }
+        } ), { status: 200 } ),
+        new Response( JSON.stringify( { message: 'Not Found' } ), { status: 404 } ),
+        new Response( JSON.stringify( { message: 'Conflict' } ), { status: 409 } ),
+        new Response( JSON.stringify( {
+            ref: 'refs/pull/19/head',
+            object: { type: 'commit', sha: SHA_C }
+        } ), { status: 200 } ),
+        new Response( JSON.stringify( {
+            ref: 'refs/pull/19/merge',
+            object: { type: 'tag', sha: SHA_C }
+        } ), { status: 200 } ),
+        new Response( JSON.stringify( {
+            ref: 'refs/pull/19/merge',
+            object: { type: 'commit', sha: 'invalid' }
+        } ), { status: 200 } )
+    ];
+    var api = module.createGitHubApi( {
+        token: 'token',
+        repository: REPOSITORY,
+        fetchImpl: async function( url, options )
+        {
+            requests.push( { url: url, options: options } );
+            return responses.shift();
+        }
+    } );
+
+    assert.equal( await api.getPullRequestMergeSha( 19 ), SHA_C );
+    assert.equal( await api.getPullRequestMergeSha( 19 ), undefined );
+    assert.equal( await api.getPullRequestMergeSha( 19 ), undefined );
+    for( var index = 0; index < 2; index++ )
+    {
+        await assert.rejects( api.getPullRequestMergeSha( 19 ), function( error )
+        {
+            return error instanceof module.PrVsixInvariantError &&
+                error.message === 'pull request 19: invalid merge ref response';
+        } );
+    }
+    await assert.rejects( api.getPullRequestMergeSha( 19 ), function( error )
+    {
+        return error instanceof module.PrVsixInvariantError &&
+            error.message === 'pull request merge ref SHA: expected a 40-character lowercase commit SHA';
+    } );
+    assert.equal( requests.length, 6 );
+    assert.ok( requests.every( function( request )
+    {
+        return request.url.endsWith( '/repos/FanaticPythoner/better-todo-tree/git/ref/pull/19/merge' ) &&
+            request.options.headers[ 'X-GitHub-Api-Version' ] === '2026-03-10';
+    } ) );
 } );
 
 QUnit.test( 'GitHub API adapter exposes transport and response contract failures', async function( assert )

--- a/test/pr-vsix-refresh.test.js
+++ b/test/pr-vsix-refresh.test.js
@@ -13,6 +13,7 @@ var SHA_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 var SHA_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 var SHA_C = 'cccccccccccccccccccccccccccccccccccccccc';
 var SHA_D = 'dddddddddddddddddddddddddddddddddddddddd';
+var SHA_E = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 function pullRequest( overrides )
 {
@@ -21,7 +22,7 @@ function pullRequest( overrides )
         state: 'open',
         mergeable: true,
         mergeable_state: 'clean',
-        merge_commit_sha: SHA_C,
+        merge_commit_sha: null,
         author_association: 'OWNER',
         labels: [],
         head: { sha: SHA_A, repo: { id: 99 } },
@@ -94,6 +95,27 @@ function storedArtifact( overrides )
     }, overrides || {} );
 }
 
+function mergeContextApi( overrides )
+{
+    return Object.assign( {
+        getPullRequestMergeSha: async function() { return SHA_C; },
+        getCommit: async function()
+        {
+            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        }
+    }, overrides || {} );
+}
+
+function stableContext( overrides )
+{
+    return Object.assign( {
+        pullRequestNumber: 19,
+        headSha: SHA_A,
+        baseSha: SHA_B,
+        mergeSha: SHA_C
+    }, overrides || {} );
+}
+
 QUnit.module( 'PR VSIX refresh and immutable context' );
 
 QUnit.test( 'base refresh accepts only successful same-repository push signals', async function( assert )
@@ -139,13 +161,16 @@ QUnit.test( 'repository dispatch resolves only a parent-bound current merge cont
             cause: 'repair'
         }
     } );
-    var api = {
-        getPullRequest: async function() { return pullRequest(); },
-        getCommit: async function()
+    var api = mergeContextApi( {
+        getPullRequest: async function()
         {
-            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+            return pullRequest( {
+                mergeable: null,
+                mergeable_state: 'unknown',
+                merge_commit_sha: SHA_D
+            } );
         }
-    };
+    } );
 
     var context = await module.resolveBuildContext( {
         event: dispatchEvent,
@@ -181,13 +206,13 @@ QUnit.test( 'stale merge parents and unapproved external forks fail closed', asy
             cause: 'repair'
         }
     } );
-    var staleApi = {
+    var staleApi = mergeContextApi( {
         getPullRequest: async function() { return pullRequest(); },
         getCommit: async function()
         {
             return { sha: SHA_C, parents: [ { sha: SHA_D }, { sha: SHA_A } ] };
         }
-    };
+    } );
     await assert.rejects( module.resolveBuildContext( {
         event: dispatchEvent,
         api: staleApi,
@@ -201,14 +226,9 @@ QUnit.test( 'stale merge parents and unapproved external forks fail closed', asy
         author_association: 'NONE',
         head: { sha: SHA_A, repo: { id: 2 } }
     } );
-    var externalApi = {
-        getPullRequest: async function() { return external; },
-        getCommit: staleApi.getCommit
-    };
-    externalApi.getCommit = async function()
-    {
-        return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
-    };
+    var externalApi = mergeContextApi( {
+        getPullRequest: async function() { return external; }
+    } );
     await assert.rejects( module.resolveBuildContext( {
         event: dispatchEvent,
         api: externalApi,
@@ -234,7 +254,7 @@ QUnit.test( 'revocation dispatch resolves to trusted cleanup without PR checkout
                 pull_request_number: 19,
                 head_sha: SHA_A,
                 base_sha: SHA_B,
-                merge_sha: SHA_C,
+                merge_sha: 'none',
                 cause: 'approval-revoked'
             }
         } ),
@@ -329,6 +349,7 @@ QUnit.test( 'scheduled refresh preserves current bundles outside the renewal win
     var module = await refreshModulePromise;
     var refresh = module.requiresScheduledRefresh( {
         pullRequest: pullRequest(),
+        context: stableContext(),
         comments: [ comment( markerBody() ) ],
         artifacts: [ storedArtifact() ],
         now: Date.parse( '2026-07-11T12:00:00Z' ),
@@ -344,6 +365,7 @@ QUnit.test( 'scheduled refresh repairs context drift, expiry, and abandoned pend
     var module = await refreshModulePromise;
     var input = {
         pullRequest: pullRequest(),
+        context: stableContext(),
         comments: [ comment( markerBody() ) ],
         artifacts: [ storedArtifact() ],
         now: Date.parse( '2026-07-11T18:01:00Z' ),
@@ -401,6 +423,7 @@ QUnit.test( 'base refresh dispatches build and conflict invalidation events', as
 {
     var module = await refreshModulePromise;
     var dispatched = [];
+    var mergeRefPulls = [];
     var pulls = [
         pullRequest(),
         pullRequest( {
@@ -410,7 +433,12 @@ QUnit.test( 'base refresh dispatches build and conflict invalidation events', as
             merge_commit_sha: null
         } )
     ];
-    var api = {
+    var api = mergeContextApi( {
+        getPullRequestMergeSha: async function( number )
+        {
+            mergeRefPulls.push( number );
+            return SHA_C;
+        },
         listOpenPullRequests: async function( base )
         {
             assert.equal( base, 'master' );
@@ -420,15 +448,11 @@ QUnit.test( 'base refresh dispatches build and conflict invalidation events', as
         {
             return pulls.find( function( item ) { return item.number === number; } );
         },
-        getCommit: async function()
-        {
-            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
-        },
         dispatchRepositoryEvent: async function( name, payload )
         {
             dispatched.push( { name: name, payload: payload } );
         }
-    };
+    } );
     var result = await module.refreshOpenPullRequests( {
         api: api,
         base: 'master',
@@ -454,6 +478,7 @@ QUnit.test( 'base refresh dispatches build and conflict invalidation events', as
         return left.payload.pull_request_number - right.payload.pull_request_number;
     } );
     assert.equal( dispatched[ 0 ].name, 'refresh-pr-vsix' );
+    assert.deepEqual( mergeRefPulls, [ 19 ] );
     assert.deepEqual( dispatched[ 0 ].payload, {
         pull_request_number: 19,
         head_sha: SHA_A,
@@ -467,23 +492,37 @@ QUnit.test( 'base refresh dispatches build and conflict invalidation events', as
 QUnit.test( 'base refresh returns a durable PR-number continuation cursor', async function( assert )
 {
     var module = await refreshModulePromise;
-    var pulls = [ pullRequest(), pullRequest( { number: 20 } ), pullRequest( { number: 21 } ) ];
+    var pulls = [
+        pullRequest(),
+        pullRequest( { number: 20, head: { sha: SHA_D, repo: { id: 99 } } } ),
+        pullRequest( { number: 21 } )
+    ];
     var dispatched = [];
-    var api = {
+    var mergeRefPulls = [];
+    var commitReads = [];
+    var api = mergeContextApi( {
+        getPullRequestMergeSha: async function( number )
+        {
+            mergeRefPulls.push( number );
+            return number === 19 ? SHA_C : SHA_E;
+        },
+        getCommit: async function( sha )
+        {
+            commitReads.push( sha );
+            return sha === SHA_C ?
+                { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] } :
+                { sha: SHA_E, parents: [ { sha: SHA_B }, { sha: SHA_D } ] };
+        },
         listOpenPullRequests: async function() { return pulls; },
         getPullRequest: async function( number )
         {
             return pulls.find( function( pull ) { return pull.number === number; } );
         },
-        getCommit: async function()
-        {
-            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
-        },
         dispatchRepositoryEvent: async function( name, payload )
         {
             dispatched.push( { name: name, payload: payload } );
         }
-    };
+    } );
     var result = await module.refreshOpenPullRequests( {
         api: api,
         base: 'master',
@@ -498,6 +537,15 @@ QUnit.test( 'base refresh returns a durable PR-number continuation cursor', asyn
 
     assert.equal( result.scanned, 2 );
     assert.equal( dispatched.length, 2 );
+    assert.deepEqual( mergeRefPulls.sort(), [ 19, 20 ] );
+    assert.deepEqual( commitReads.sort(), [ SHA_C, SHA_E ] );
+    assert.deepEqual( dispatched.sort( function( left, right )
+    {
+        return left.payload.pull_request_number - right.payload.pull_request_number;
+    } ).map( function( item )
+    {
+        return [ item.payload.pull_request_number, item.payload.merge_sha ];
+    } ), [ [ 19, SHA_C ], [ 20, SHA_E ] ] );
     assert.deepEqual( result.continuation, { phase: 'open', cursor: 20 } );
 } );
 
@@ -525,13 +573,9 @@ QUnit.test( 'scheduled sweep dispatches only stale bundles', async function( ass
 {
     var module = await refreshModulePromise;
     var dispatched = [];
-    var api = {
+    var api = mergeContextApi( {
         listOpenPullRequests: async function() { return [ pullRequest() ]; },
         getPullRequest: async function() { return pullRequest(); },
-        getCommit: async function()
-        {
-            return { sha: SHA_C, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
-        },
         listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
         listRepositoryArtifacts: async function()
         {
@@ -541,7 +585,7 @@ QUnit.test( 'scheduled sweep dispatches only stale bundles', async function( ass
         {
             dispatched.push( { name: name, payload: payload } );
         }
-    };
+    } );
     var result = await module.refreshOpenPullRequests( {
         api: api,
         scheduled: true,
@@ -564,6 +608,150 @@ QUnit.test( 'scheduled sweep dispatches only stale bundles', async function( ass
     } );
     assert.equal( dispatched.length, 1 );
     assert.equal( dispatched[ 0 ].payload.cause, 'renewal' );
+} );
+
+QUnit.test( 'scheduled sweep revalidates the exact canonical merge ref', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var mergeSha = SHA_C;
+    var mergeRefReads = [];
+    var dispatched = [];
+    var api = {
+        listOpenPullRequests: async function() { return [ pullRequest() ]; },
+        getPullRequest: async function() { return pullRequest(); },
+        getPullRequestMergeSha: async function( number )
+        {
+            mergeRefReads.push( number );
+            return mergeSha;
+        },
+        getCommit: async function( sha )
+        {
+            return { sha: sha, parents: [ { sha: SHA_B }, { sha: SHA_A } ] };
+        },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function() { return [ storedArtifact() ]; },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+    var options = {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z'
+    };
+
+    var current = await module.refreshOpenPullRequests( options );
+    assert.equal( current.current, 1 );
+    assert.equal( current.dispatched, 0 );
+    assert.deepEqual( dispatched, [] );
+
+    mergeSha = SHA_D;
+    var repaired = await module.refreshOpenPullRequests( options );
+    assert.equal( repaired.current, 0 );
+    assert.equal( repaired.dispatched, 1 );
+    assert.equal( dispatched.length, 1 );
+    assert.deepEqual( dispatched[ 0 ].payload, {
+        pull_request_number: 19,
+        head_sha: SHA_A,
+        base_sha: SHA_B,
+        merge_sha: SHA_D,
+        cause: 'repair'
+    } );
+    assert.deepEqual( mergeRefReads, [ 19, 19 ] );
+} );
+
+QUnit.test( 'scheduled sweep revokes authorization removed during merge reconciliation', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var allowed = pullRequest( {
+        author_association: 'NONE',
+        labels: [ { name: 'safe-to-test' } ],
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var revoked = pullRequest( {
+        author_association: 'NONE',
+        labels: [],
+        head: { sha: SHA_A, repo: { id: 2 } }
+    } );
+    var dispatched = [];
+    var api = {
+        listOpenPullRequests: async function() { return [ allowed ]; },
+        getPullRequest: async function() { return revoked; },
+        getPullRequestMergeSha: async function()
+        {
+            throw new Error( 'merge ref must not be read after revocation' );
+        },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function() { return [ storedArtifact() ]; },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z'
+    } );
+
+    assert.equal( result.revoked, 1 );
+    assert.equal( result.unsafe, 0 );
+    assert.equal( dispatched.length, 1 );
+    assert.equal( dispatched[ 0 ].payload.cause, 'approval-revoked' );
+    assert.equal( dispatched[ 0 ].payload.merge_sha, 'none' );
+} );
+
+QUnit.test( 'scheduled sweep repairs closure observed during merge reconciliation', async function( assert )
+{
+    var module = await refreshModulePromise;
+    var closed = pullRequest( {
+        state: 'closed',
+        closed_at: '2026-07-11T11:00:00Z'
+    } );
+    var dispatched = [];
+    var api = {
+        listOpenPullRequests: async function() { return [ pullRequest() ]; },
+        getPullRequest: async function() { return closed; },
+        getPullRequestMergeSha: async function()
+        {
+            throw new Error( 'merge ref must not be read after closure' );
+        },
+        listRepositoryIssueComments: async function() { return [ comment( markerBody() ) ]; },
+        listRepositoryArtifacts: async function() { return [ storedArtifact() ]; },
+        dispatchRepositoryEvent: async function( name, payload )
+        {
+            dispatched.push( { name: name, payload: payload } );
+        }
+    };
+
+    var result = await module.refreshOpenPullRequests( {
+        api: api,
+        scheduled: true,
+        now: Date.parse( '2026-07-11T12:00:00Z' ),
+        renewalWindowMs: 14 * 24 * 60 * 60 * 1000,
+        pendingWindowMs: 6 * 60 * 60 * 1000,
+        concurrency: 1,
+        mergeRetry: { attempts: 1, intervalMs: 0 },
+        commentSince: '2026-04-11T12:00:00Z'
+    } );
+
+    assert.equal( result.closedRepaired, 1 );
+    assert.equal( result.skipped, 0 );
+    assert.equal( dispatched.length, 1 );
+    assert.equal( dispatched[ 0 ].payload.cause, 'closed-repair' );
+    assert.equal( dispatched[ 0 ].payload.merge_sha, 'none' );
 } );
 
 QUnit.test( 'refresh sweep does not execute unapproved external fork code', async function( assert )
@@ -703,6 +891,11 @@ QUnit.test( 'scheduled grouping retains orphan artifacts after blocked comment c
     var grouped = module.groupScheduledState( [ pullRequest() ], [ blocked ], [ storedArtifact() ] );
 
     assert.equal( grouped.artifactsByName.get( 'better-todo-tree-pr-19.vsix' ).length, 1 );
+    assert.notOk( module.requiresAuthorizationRevocation( {
+        pullRequest: pullRequest(),
+        comments: [ blocked ],
+        artifacts: []
+    } ) );
     assert.ok( module.requiresAuthorizationRevocation( {
         pullRequest: pullRequest(),
         comments: [ blocked ],

--- a/test/workflows.github.test.js
+++ b/test/workflows.github.test.js
@@ -595,8 +595,11 @@ QUnit.test( 'privileged PR VSIX publisher executes trusted metadata code only', 
     assert.ok( eventWorkflow.indexOf( 'pull_request_target:\n    types:\n      - closed\n      - edited\n      - labeled\n      - unlabeled\n      - opened\n      - reopened\n      - synchronize' ) !== -1 );
     assert.ok( eventWorkflow.indexOf( "github.event.action != 'edited' || github.event.changes.base != null" ) !== -1 );
     assert.ok( eventWorkflow.indexOf( "github.event.action != 'labeled' && github.event.action != 'unlabeled'" ) !== -1 );
-    assert.ok( eventWorkflow.indexOf( 'better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'better-todo-tree-pr-vsix-event-${{ github.event.pull_request.number }}-head-${{ github.event.pull_request.head.sha }}-base-${{ github.event.pull_request.base.sha }}-merge-none-' ) !== -1 );
     assert.ok( eventWorkflow.indexOf( '-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}' ) !== -1 );
+    assert.ok( eventWorkflow.indexOf( 'merge_commit_sha' ) === -1 );
+    assert.ok( publisherScript.indexOf( 'merge_commit_sha' ) === -1 );
+    assert.ok( publisherScript.indexOf( '/git/ref/pull/' ) !== -1 );
     assert.ok( eventWorkflow.indexOf( 'actions/checkout' ) === -1 );
     assert.ok( eventWorkflow.indexOf( 'permissions: {}' ) !== -1 );
     assert.ok( eventWorkflow.indexOf( 'pull-requests: write' ) === -1 );


### PR DESCRIPTION
Resolve the canonical pull-request merge ref and require exact ordered merge
parents before dispatch or publication. Revalidate source, authorization, and
merge identity across callbacks, retries, lifecycle events, and scheduled
refreshes.

Reconciliation:
- preserve valid previews across stale, failed, renewal, and duplicate runs
- invalidate comments and artifacts for closed or unauthorized pull requests
- remove superseded artifacts without deleting newer valid generations
- repair merge, approval, closure, and API race paths with explicit failures

Coverage:
- add deterministic merge-ref, stale-callback, cleanup-ordering, API-failure,
  refresh, and workflow-invariant tests
